### PR TITLE
fix bulk method - Corrige erro de digitação de linha de código

### DIFF
--- a/am2opac.py
+++ b/am2opac.py
@@ -595,7 +595,6 @@ def bulk(options, pool):
         pool.map(process_journal, pissns)
         pool.map(process_issue, pissns)
         pool.map(process_article, pissns)
-        poll.map(process_article(pissns))
 
 
 def serial(options):


### PR DESCRIPTION
Durante o processo de importação da coleção brasil encontrei um traceback informando um erro no trecho de código corrigido aqui.

Ao ler o método percebi que existia um erro de digitação e fiz uma correção rápida. Se for necessário posso criar um issue para este PR.

**Caso de Teste:**
- Execute a importação da coleção SciELO Brasil.
- No `setup.py` setar `OPAC_PROC_COLLECTION = os.environ.get('OPAC_PROC_COLLECTION', 'scl')`
- Execute: `python am2opac.py`
- Validar se os dados foram importados corretamente