### PR TITLE
Corrige porta padrão para acesso ao articlemeta

### DIFF
--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -22,7 +22,7 @@ ARTICLE_META_THRIFT_DOMAIN = os.environ.get(
     'articlemeta.scielo.org')
 ARTICLE_META_THRIFT_PORT = int(os.environ.get(
     'OPAC_PROC_ARTICLE_META_THRIFT_PORT',
-    11620))  # antes 11720
+    11621))  # antes 11720
 
 # WEBAPP config: ----------------------------------------------------
 DEBUG = bool(os.environ.get('OPAC_PROC_DEBUG', True))

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -22,7 +22,7 @@ ARTICLE_META_THRIFT_DOMAIN = os.environ.get(
     'articlemeta.scielo.org')
 ARTICLE_META_THRIFT_PORT = int(os.environ.get(
     'OPAC_PROC_ARTICLE_META_THRIFT_PORT',
-    11621))  # antes 11720
+    11621))
 
 # WEBAPP config: ----------------------------------------------------
 DEBUG = bool(os.environ.get('OPAC_PROC_DEBUG', True))


### PR DESCRIPTION
Com a alteração da porta onde o serviço está sendo disponibilizado foi necessário alterar a configuração padrão para garantir o pleno funcionamento do app. 