### PR TITLE
features e ajustes nas listagens e salvando campo de "data_model_version" na tranformação

### DIFF
--- a/opac_proc/transformers/tr_articles.py
+++ b/opac_proc/transformers/tr_articles.py
@@ -146,6 +146,13 @@ class ArticleTransformer(BaseTransformer):
             if pdfs:
                 self.transform_model_instance['pdfs'] = pdfs
 
+        # salvamos typo de artigo na fonte: xml ou html
+        if hasattr(xylose_article, 'data_model_version'):
+            if xylose_article.data_model_version == 'xml':
+                self.transform_model_instance['data_model_version'] = 'xml'
+            else:
+                self.transform_model_instance['data_model_version'] = 'html'
+
         asset_html = AssetHTMLS(xylose_article)
 
         # Versão XML do artigo

--- a/opac_proc/web/templates/includes/page_header.html
+++ b/opac_proc/web/templates/includes/page_header.html
@@ -4,5 +4,9 @@
         {% if page_subtitle %}
             <small>{{ page_subtitle }}</small>
         {% endif %}
+
+        <a href="#" id="refresh_page" class="btn btn-primary pull-right">
+          <i class="fa fa-refresh"></i> Refresh page
+        </a>
     </h2>
 </div>

--- a/opac_proc/web/templates/object_list/base.html
+++ b/opac_proc/web/templates/object_list/base.html
@@ -14,6 +14,32 @@
       <span class="pull-right">
         <strong>Página:</strong> {{ current_page }} / {{ total_pages }} &bull;
         <strong>Registros:</strong> <span class="badge">{{ total_records }}</span>
+
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Per Page ({{ per_page }}) <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-right">
+            <li {% if per_page == 10 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="10">10 per page</a>
+            </li>
+            <li {% if per_page == 20 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="20">20 per page</a>
+            </li>
+            <li {% if per_page == 50 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="50">50 per page</a>
+            </li>
+            <li {% if per_page == 100 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="100">100 per page</a>
+            </li>
+            <li {% if per_page == 500 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="500">500 per page</a>
+            </li>
+            <li {% if per_page == 1000 %} class="active" {% endif %}>
+              <a href="#" class="change_page_size" data-page-size="1000">1000 per page</a>
+            </li>
+          </ul>
+        </div>
       </span>
     </div>
     <table class="table_object_list table table-striped table-hover">
@@ -44,6 +70,11 @@
         {% endfor %}
       </thead>
       <tbody class="tbody_object_list">
+        <tr class="count_selected_rows" style="display:none">
+          <td colspan="{{ list_columns|length + 1 }}" style="text-align:center;"  class="bg-warning">
+            <span class="count_msg"></span>
+          </td>
+        </tr>
         {% for object in objects  %}
           <tr>
             <th>
@@ -72,7 +103,7 @@
               <ul class="pagination" >
                 {% if has_prev %}
                   <li>
-                    <a href="?page={{ prev_num }}" aria-label="Previous">
+                    <a class="goto_page" data-page="{{ prev_num }}" href="#" aria-label="Previous">
                       <span aria-hidden="true">&laquo;</span>
                     </a>
                   </li>
@@ -87,24 +118,24 @@
                 {% for page_num in pager_range.range %}
                   {% if loop.first and pager_range.has_more_prevs %}
                     <li>
-                      <a href="?page={{ page_num }}">...</a>
+                      <a class="goto_page" data-page="{{ page_num }}" href="#">...</a>
                     </li>
                   {% endif %}
 
                   <li {% if page_num == current_page %} class="active" {% endif %}>
-                    <a href="?page={{ page_num }}">{{ page_num }}</a>
+                    <a class="goto_page" data-page="{{ page_num }}" href="#">{{ page_num }}</a>
                   </li>
 
                   {% if loop.last and pager_range.has_more_nexts %}
                     <li>
-                      <a href="?page={{ page_num }}">...</a>
+                      <a class="goto_page" data-page="{{ page_num }}" href="#">...</a>
                     </li>
                   {% endif %}
                 {% endfor %}
 
                 {% if has_next %}
                   <li>
-                    <a href="?page={{ next_num }}" aria-label="Next">
+                    <a class="goto_page" data-page="{{ next_num }}" href="#" aria-label="Next">
                       <span aria-hidden="true">&raquo;</span>
                     </a>
                   </li>
@@ -132,15 +163,81 @@
   <script src="{{ url_for('static', filename='js/actions_toolbar.js') }}"></script>
   <script src="{{ url_for('static', filename='js/filters_toolbar.js') }}"></script>
   <script type="text/javascript">
+
+    function updateQueryStringParameter(uri, key, value) {
+      var _value = encodeURIComponent(value);
+      var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+      var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+      if (uri.match(re)) {
+        return uri.replace(re, '$1' + key + "=" + _value + '$2');
+      }
+      else {
+        return uri + separator + key + "=" + _value;
+      }
+    }
+
+
     $(function() {
-      $('#table_check_all:checkbox').click(function(event) {
+
+      function hide_count_selected_rows(){
+        var row = $('tr.count_selected_rows');
+        row.hide();
+      }
+
+      function show_count_selected_rows(count){
+        var msg = '';
+        if (count === 1) {
+          msg = count + ' linha selecionada!'
+        } else {
+          msg = count + ' linhas selecionadas!'
+        }
+        var row = $('tr.count_selected_rows');
+        row.find('.count_msg').text(msg);
+        row.show();
+      }
+
+      function count_checked_rows_and_display(){
+        var count = $('input:checkbox:checked', '.tbody_object_list').size();
+        if (count > 0){
+          show_count_selected_rows(count);
+        } else {
+          hide_count_selected_rows();
+        }
+      }
+
+      $('#refresh_page').click(function(e) {
+        e.preventDefault()
+        window.location = window.location;
+      });
+
+      $('.change_page_size').click(function(e) {
+        e.preventDefault();
+        var per_page = $(this).data('page-size')
+        window.location.href = updateQueryStringParameter(window.location.href, 'per_page', per_page);
+      });
+
+      $('.goto_page').click(function (e) {
+        e.preventDefault();
+        var page_num = $(this).data('page');
+        window.location.href = updateQueryStringParameter(window.location.href, 'page', page_num);
+      });
+
+      $('#table_check_all:checkbox').click(function(e) {
         var $this = $(this);
         if ($this.is(":checked")) {
           $('input:checkbox', '.tbody_object_list').prop('checked', true);
         } else {
           $('input:checkbox', '.tbody_object_list').prop('checked', false);
         }
+        count_checked_rows_and_display();
       });
+
+      $('input:checkbox', '.tbody_object_list').click(function(event) {
+        count_checked_rows_and_display();
+      });
+
+      /* chamada para mostara fila cuando a pagina é carregada */
+      count_checked_rows_and_display();
       ActionToolbar.init();
       /* filters toolbar */
       {% for field_filter in list_filters %}

--- a/opac_proc/web/views/generics/list_views.py
+++ b/opac_proc/web/views/generics/list_views.py
@@ -359,6 +359,12 @@ class ListView(View):
 
         # listamos os registros
         page = request.args.get('page', 1, type=int)
+
+        new_per_page = request.args.get('per_page', self.per_page, type=int)
+        if self.per_page != new_per_page:
+            if new_per_page in [10, 20, 50, 100, 500, 1000]:
+                self.per_page = new_per_page
+
         objects = Pagination(self.get_objects(), page, self.per_page)
         context = {
             # stage: 'extract' || 'transform' || 'load' || 'opac'
@@ -380,6 +386,7 @@ class ListView(View):
             # paginas:
             'pager_range': self._pager_range(page, objects.pages),
             'current_page': page,
+            'per_page': self.per_page,
             'total_pages': objects.pages,
             'total_records': objects.total,
             'has_prev': objects.has_prev,

--- a/opac_proc/web/views/transform/list_views.py
+++ b/opac_proc/web/views/transform/list_views.py
@@ -267,6 +267,11 @@ class TransformArticleListView(TransformBaseListView):
             'field_type': 'string'
         },
         {
+            'field_label': u'Versão (xml/html)',
+            'field_name': 'data_model_version',
+            'field_type': 'string'
+        },
+        {
             'field_label': u'Last update:',
             'field_name': 'updated_at',
             'field_type': 'date_time'
@@ -292,6 +297,11 @@ class TransformArticleListView(TransformBaseListView):
         {
             'field_label': u'PID',
             'field_name': 'pid',
+            'field_type': 'string'
+        },
+        {
+            'field_label': u'Versão (xml/html)',
+            'field_name': 'data_model_version',
             'field_type': 'string'
         },
         {


### PR DESCRIPTION
- mudança de tamanho de página (per page) com as opções: [10, 20, 50, 100, 500, 1000]
- notificação da quantidade de filas selecionadas (checkboxes)
- fix link da paginação que ignorava a querystring
- add botão de "refesh page"
- agora na transformação salvamos o campo de "data_model_version" para os artigos