### PR TITLE
update requirement opac_schema to v2.40 and workaround

### DIFF
--- a/opac_proc/web/templates/macros/object_list.html
+++ b/opac_proc/web/templates/macros/object_list.html
@@ -4,11 +4,19 @@
         {{ object[field_name] }}
     {% elif field_type == 'date' %}
         {% if object[field_name] %}
-            {{ object[field_name].strftime('%Y-%m-%d') }}
+            {% if object[field_name]|string %} {# workarround resolvido no proc parcial #}
+                {{ object[field_name] }}
+            {% else %}
+                {{ object[field_name].strftime('%Y-%m-%d') }}
+            {% endif %}
         {% endif %}
     {% elif field_type == 'date_time' %}
         {% if object[field_name] %}
-            {{ object[field_name].strftime('%Y-%m-%d %H:%M:%S') }}
+            {% if object[field_name]|string %} {# workarround resolvido no proc parcial #}
+                {{ object[field_name] }}
+            {% else %}
+                {{ object[field_name].strftime('%Y-%m-%d %H:%M:%S') }}
+            {% endif %}
         {% endif %}
     {% elif field_type == 'boolean' %}
         {% if object[field_name] %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ blinker==1.4
 mongolog==0.1.1
 xylose==1.31.0
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.38#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.40#egg=opac_schema
 scieloh5m5==1.10.4
 requests==2.18.4
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
the workaround:
To avoid the conversion of unicode fields (from ArticleMeta) to date/datetime objects

The definitive fix is done in the branch with partial processing