### PR TITLE
fixes processing diff (ETL) + ui improvements

### DIFF
--- a/opac_proc/datastore/models.py
+++ b/opac_proc/datastore/models.py
@@ -52,7 +52,7 @@ class ExtractCollection(BaseMixin, DynamicDocument):
         """
         return {
             'uuid': self.uuid,
-            'collection_acronym': self.acronym,
+            'collection_acronym': config.OPAC_PROC_COLLECTION,
         }
 
     meta = {
@@ -363,7 +363,7 @@ class TransformJournal(BaseMixin, DynamicDocument):
         """
         return {
             'uuid': self.uuid,
-            'collection_acronym': self.collection,
+            'collection_acronym': config.OPAC_PROC_COLLECTION,
             'journal_issn': self.get_issn
         }
 
@@ -623,7 +623,7 @@ class LoadJournal(BaseMixin, DynamicDocument):
         """
         return {
             'uuid': self.uuid,
-            'collection_acronym': self.loaded_data.collection,
+            'collection_acronym': config.OPAC_PROC_COLLECTION,
             'journal_issn': self.get_issn
         }
 

--- a/opac_proc/datastore/mongodb_connector.py
+++ b/opac_proc/datastore/mongodb_connector.py
@@ -41,7 +41,7 @@ def get_db_connection():
     else:
         db_name = get_opac_proc_db_name()
         msg = u"Conexão establecida com banco: %s!" % db_name
-        logger.info(msg)
+        logger.debug(msg)
         return db
 
 

--- a/opac_proc/source_sync/differ_consumer_jobs.py
+++ b/opac_proc/source_sync/differ_consumer_jobs.py
@@ -31,8 +31,8 @@ DIFFERS = {  # mover para utils.py
     'journal': JournalDiffer,
     'issue': IssueDiffer,
     'article': ArticleDiffer,
-    'news': PressReleaseDiffer,
-    'press_release': NewsDiffer,
+    'news': NewsDiffer,
+    'press_release': PressReleaseDiffer,
 }
 
 
@@ -51,8 +51,8 @@ def task_differ_apply_for_selected_uuids(stage, model_name, action, uuids):
 
     diff_class = DIFFERS[model_name]
     diff_class_instance = diff_class()
-    for target_uuid in uuids:
-        diff_class_instance.apply_diff_record(stage, action, target_uuid)
+    # passamos a lista de uuids a aplicar
+    diff_class_instance.apply_diff_record(stage, action, uuids)
 
 
 def enqueue_differ_consumer_tasks(stage='all', model_name='all', action='all'):

--- a/opac_proc/source_sync/differ_producer_jobs.py
+++ b/opac_proc/source_sync/differ_producer_jobs.py
@@ -31,8 +31,8 @@ DIFFERS = {
     'journal': JournalDiffer,
     'issue': IssueDiffer,
     'article': ArticleDiffer,
-    'news': PressReleaseDiffer,
-    'press_release': NewsDiffer,
+    'news': NewsDiffer,
+    'press_release': PressReleaseDiffer,
 }
 
 

--- a/opac_proc/web/templates/home.html
+++ b/opac_proc/web/templates/home.html
@@ -780,92 +780,92 @@
             <tr>
               <td>Collection:</td>
               {# extract #}
-              <td>{{ diff_ex_add_collection_count }}</td>
-              <td>{{ diff_ex_upd_collection_count }}</td>
-              <td>{{ diff_ex_del_collection_count }}</td>
+              <td {% if diff_ex_add_collection_count %} class="warning" {% endif %}>{{ diff_ex_add_collection_count }}</td>
+              <td {% if diff_ex_upd_collection_count %} class="warning" {% endif %}>{{ diff_ex_upd_collection_count }}</td>
+              <td {% if diff_ex_del_collection_count %} class="warning" {% endif %}>{{ diff_ex_del_collection_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_collection_count }}</td>
-              <td>{{ diff_tr_upd_collection_count }}</td>
-              <td>{{ diff_tr_del_collection_count }}</td>
+              <td {% if diff_tr_add_collection_count %} class="warning" {% endif %}>{{ diff_tr_add_collection_count }}</td>
+              <td {% if diff_tr_upd_collection_count %} class="warning" {% endif %}>{{ diff_tr_upd_collection_count }}</td>
+              <td {% if diff_tr_del_collection_count %} class="warning" {% endif %}>{{ diff_tr_del_collection_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_collection_count }}</td>
-              <td>{{ diff_lo_upd_collection_count }}</td>
-              <td>{{ diff_lo_del_collection_count }}</td>
+              <td {% if diff_lo_add_collection_count %} class="warning" {% endif %}>{{ diff_lo_add_collection_count }}</td>
+              <td {% if diff_lo_upd_collection_count %} class="warning" {% endif %}>{{ diff_lo_upd_collection_count }}</td>
+              <td {% if diff_lo_del_collection_count %} class="warning" {% endif %}>{{ diff_lo_del_collection_count }}</td>
             </tr>
             <tr>
               <td>Journal:</td>
               {# extract #}
-              <td>{{ diff_ex_add_journal_count }}</td>
-              <td>{{ diff_ex_upd_journal_count }}</td>
-              <td>{{ diff_ex_del_journal_count }}</td>
+              <td {% if diff_ex_add_journal_count %} class="warning" {% endif %}>{{ diff_ex_add_journal_count }}</td>
+              <td {% if diff_ex_upd_journal_count %} class="warning" {% endif %}>{{ diff_ex_upd_journal_count }}</td>
+              <td {% if diff_ex_del_journal_count %} class="warning" {% endif %}>{{ diff_ex_del_journal_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_journal_count }}</td>
-              <td>{{ diff_tr_upd_journal_count }}</td>
-              <td>{{ diff_tr_del_journal_count }}</td>
+              <td {% if diff_tr_add_journal_count %} class="warning" {% endif %}>{{ diff_tr_add_journal_count }}</td>
+              <td {% if diff_tr_upd_journal_count %} class="warning" {% endif %}>{{ diff_tr_upd_journal_count }}</td>
+              <td {% if diff_tr_del_journal_count %} class="warning" {% endif %}>{{ diff_tr_del_journal_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_journal_count }}</td>
-              <td>{{ diff_lo_upd_journal_count }}</td>
-              <td>{{ diff_lo_del_journal_count }}</td>
+              <td {% if diff_lo_add_journal_count %} class="warning" {% endif %}>{{ diff_lo_add_journal_count }}</td>
+              <td {% if diff_lo_upd_journal_count %} class="warning" {% endif %}>{{ diff_lo_upd_journal_count }}</td>
+              <td {% if diff_lo_del_journal_count %} class="warning" {% endif %}>{{ diff_lo_del_journal_count }}</td>
             </tr>
             <tr>
               <td>Issue:</td>
               {# extract #}
-              <td>{{ diff_ex_add_issue_count }}</td>
-              <td>{{ diff_ex_upd_issue_count }}</td>
-              <td>{{ diff_ex_del_issue_count }}</td>
+              <td {% if diff_ex_add_issue_count %} class="warning" {% endif %}>{{ diff_ex_add_issue_count }}</td>
+              <td {% if diff_ex_upd_issue_count %} class="warning" {% endif %}>{{ diff_ex_upd_issue_count }}</td>
+              <td {% if diff_ex_del_issue_count %} class="warning" {% endif %}>{{ diff_ex_del_issue_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_issue_count }}</td>
-              <td>{{ diff_tr_upd_issue_count }}</td>
-              <td>{{ diff_tr_del_issue_count }}</td>
+              <td {% if diff_tr_add_issue_count %} class="warning" {% endif %}>{{ diff_tr_add_issue_count }}</td>
+              <td {% if diff_tr_upd_issue_count %} class="warning" {% endif %}>{{ diff_tr_upd_issue_count }}</td>
+              <td {% if diff_tr_del_issue_count %} class="warning" {% endif %}>{{ diff_tr_del_issue_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_issue_count }}</td>
-              <td>{{ diff_lo_upd_issue_count }}</td>
-              <td>{{ diff_lo_del_issue_count }}</td>
+              <td {% if diff_lo_add_issue_count %} class="warning" {% endif %}>{{ diff_lo_add_issue_count }}</td>
+              <td {% if diff_lo_upd_issue_count %} class="warning" {% endif %}>{{ diff_lo_upd_issue_count }}</td>
+              <td {% if diff_lo_del_issue_count %} class="warning" {% endif %}>{{ diff_lo_del_issue_count }}</td>
             </tr>
             <tr>
               <td>Article:</td>
               {# extract #}
-              <td>{{ diff_ex_add_article_count }}</td>
-              <td>{{ diff_ex_upd_article_count }}</td>
-              <td>{{ diff_ex_del_article_count }}</td>
+              <td {% if diff_ex_add_article_count %} class="warning" {% endif %}>{{ diff_ex_add_article_count }}</td>
+              <td {% if diff_ex_upd_article_count %} class="warning" {% endif %}>{{ diff_ex_upd_article_count }}</td>
+              <td {% if diff_ex_del_article_count %} class="warning" {% endif %}>{{ diff_ex_del_article_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_article_count }}</td>
-              <td>{{ diff_tr_upd_article_count }}</td>
-              <td>{{ diff_tr_del_article_count }}</td>
+              <td {% if diff_tr_add_article_count %} class="warning" {% endif %}>{{ diff_tr_add_article_count }}</td>
+              <td {% if diff_tr_upd_article_count %} class="warning" {% endif %}>{{ diff_tr_upd_article_count }}</td>
+              <td {% if diff_tr_del_article_count %} class="warning" {% endif %}>{{ diff_tr_del_article_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_article_count }}</td>
-              <td>{{ diff_lo_upd_article_count }}</td>
-              <td>{{ diff_lo_del_article_count }}</td>
+              <td {% if diff_lo_add_article_count %} class="warning" {% endif %}>{{ diff_lo_add_article_count }}</td>
+              <td {% if diff_lo_upd_article_count %} class="warning" {% endif %}>{{ diff_lo_upd_article_count }}</td>
+              <td {% if diff_lo_del_article_count %} class="warning" {% endif %}>{{ diff_lo_del_article_count }}</td>
             </tr>
             <tr>
               <td>Press Releases:</td>
               {# extract #}
-              <td>{{ diff_ex_add_press_release_count }}</td>
-              <td>{{ diff_ex_upd_press_release_count }}</td>
-              <td>{{ diff_ex_del_press_release_count }}</td>
+              <td {% if diff_ex_add_press_release_count %} class="warning" {% endif %}>{{ diff_ex_add_press_release_count }}</td>
+              <td {% if diff_ex_upd_press_release_count %} class="warning" {% endif %}>{{ diff_ex_upd_press_release_count }}</td>
+              <td {% if diff_ex_del_press_release_count %} class="warning" {% endif %}>{{ diff_ex_del_press_release_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_press_release_count }}</td>
-              <td>{{ diff_tr_upd_press_release_count }}</td>
-              <td>{{ diff_tr_del_press_release_count }}</td>
+              <td {% if diff_tr_add_press_release_count %} class="warning" {% endif %}>{{ diff_tr_add_press_release_count }}</td>
+              <td {% if diff_tr_upd_press_release_count %} class="warning" {% endif %}>{{ diff_tr_upd_press_release_count }}</td>
+              <td {% if diff_tr_del_press_release_count %} class="warning" {% endif %}>{{ diff_tr_del_press_release_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_press_release_count }}</td>
-              <td>{{ diff_lo_upd_press_release_count }}</td>
-              <td>{{ diff_lo_del_press_release_count }}</td>
+              <td {% if diff_lo_add_press_release_count %} class="warning" {% endif %}>{{ diff_lo_add_press_release_count }}</td>
+              <td {% if diff_lo_upd_press_release_count %} class="warning" {% endif %}>{{ diff_lo_upd_press_release_count }}</td>
+              <td {% if diff_lo_del_press_release_count %} class="warning" {% endif %}>{{ diff_lo_del_press_release_count }}</td>
             </tr>
             <tr>
               <td>News:</td>
               {# extract #}
-              <td>{{ diff_ex_add_news_count }}</td>
-              <td>{{ diff_ex_upd_news_count }}</td>
-              <td>{{ diff_ex_del_news_count }}</td>
+              <td {% if diff_ex_add_news_count %} class="warning" {% endif %}>{{ diff_ex_add_news_count }}</td>
+              <td {% if diff_ex_upd_news_count %} class="warning" {% endif %}>{{ diff_ex_upd_news_count }}</td>
+              <td {% if diff_ex_del_news_count %} class="warning" {% endif %}>{{ diff_ex_del_news_count }}</td>
               {# transform #}
-              <td>{{ diff_tr_add_news_count }}</td>
-              <td>{{ diff_tr_upd_news_count }}</td>
-              <td>{{ diff_tr_del_news_count }}</td>
+              <td {% if diff_tr_add_news_count %} class="warning" {% endif %}>{{ diff_tr_add_news_count }}</td>
+              <td {% if diff_tr_upd_news_count %} class="warning" {% endif %}>{{ diff_tr_upd_news_count }}</td>
+              <td {% if diff_tr_del_news_count %} class="warning" {% endif %}>{{ diff_tr_del_news_count }}</td>
               {# load #}
-              <td>{{ diff_lo_add_news_count }}</td>
-              <td>{{ diff_lo_upd_news_count }}</td>
-              <td>{{ diff_lo_del_news_count }}</td>
+              <td {% if diff_lo_add_news_count %} class="warning" {% endif %}>{{ diff_lo_add_news_count }}</td>
+              <td {% if diff_lo_upd_news_count %} class="warning" {% endif %}>{{ diff_lo_upd_news_count }}</td>
+              <td {% if diff_lo_del_news_count %} class="warning" {% endif %}>{{ diff_lo_del_news_count }}</td>
             </tr>
           </tbody>
         </table>

--- a/opac_proc/web/templates/rq_dashboard/dashboard.html
+++ b/opac_proc/web/templates/rq_dashboard/dashboard.html
@@ -7,13 +7,15 @@
         <div class="col-md-6">
             <div class="section">
 
-                <h1>Queues</h1>
-                <p class="fixed intro">
-                    This list below contains all the registered queues with the
-                    number of jobs currently in the queue. Select a queue
-                    from above to view all jobs currently pending on the queue.
-                </p>
-
+                <h1>
+                    Queues
+                    <small>
+                        <a id="queues-list-toggle" href="#" data-status="expandend">
+                            <i id="queues-list-collapse" class="fa fa-chevron-up" style="display:none;"></i>
+                            <i id="queues-list-expand" class="fa fa-chevron-down"></i>
+                        </a>
+                    </small>
+                </h1>
                 <table id="queues" class="table table-striped">
                     <thead>
                         <tr>
@@ -52,9 +54,15 @@
         <div class="col-md-6">
             <div class="section">
 
-                <h1>Workers</h1>
-                <p class="fixed intro">This list below contains all the registered workers.</p>
-
+                <h1>
+                    Workers
+                    <small>
+                        <a id="workers-list-toggle" href="#" data-status="expandend">
+                            <i id="workers-list-collapse" class="fa fa-chevron-up" style="display:none;"></i>
+                            <i id="workers-list-expand" class="fa fa-chevron-down"></i>
+                        </a>
+                    </small>
+                </h1>
                 <table id="workers" class="table table-striped">
                     <thead>
                         <tr>
@@ -121,9 +129,11 @@
                         <i class="glyphicon glyphicon-trash glyphicon-white"></i> Empty
                     </a>
                 </div>
+
                 <p class="intro">
                     This list below contains all the registered jobs on queue <span class="label label-default">{{ queue.name }}</span>, sorted by age (oldest on top).
                 </p>
+
                 <table id="jobs" class="table table-striped">
                     <thead>
                         <tr>
@@ -232,6 +242,44 @@
     clipboard.on('success', function(e) {
         alert('Os args do job foram copiados!');
         e.clearSelection();
+    });
+
+    $('#workers-list-toggle').click(function(event){
+        event.preventDefault();
+        var current_status = $(this).data('status');
+        console.log('current_status: ', current_status);
+        if (current_status === "expandend") {
+            // novo status: "collapsed"
+            $('#workers-list-collapse').show();
+            $('#workers-list-expand').hide()
+            $('table#workers').hide();
+            $(this).data('status', "collapsed");
+        } else {
+            // novo status: "expandend"
+            $('#workers-list-collapse').hide();
+            $('#workers-list-expand').show()
+            $('table#workers').show();
+            $(this).data('status', "expandend");
+        }
+    });
+
+    $('#queues-list-toggle').click(function(event){
+        event.preventDefault();
+        var current_status = $(this).data('status');
+        console.log('current_status: ', current_status);
+        if (current_status === "expandend") {
+            // novo status: "collapsed"
+            $('#queues-list-collapse').show();
+            $('#queues-list-expand').hide()
+            $('table#queues').hide();
+            $(this).data('status', "collapsed");
+        } else {
+            // novo status: "expandend"
+            $('#queues-list-collapse').hide();
+            $('#queues-list-expand').show()
+            $('table#queues').show();
+            $(this).data('status', "expandend");
+        }
     });
 
 


### PR DESCRIPTION
- fix Extract identifier data
- fix logger message level for db connections
- improvemnt: when deleting Load records also delete OPAC models records to keep it in sync
- improvemnt: `differ.apply_diff_record` now process lists of uuids instead of unefficient "selected > one" loop
- workaround: when collecting diff records from news | press releases.
- fix: typo confussing News with press releases
- improvement: @ home, diff table now highlights when have any records with yellow backgoud
- improvement: @ dashboard now we can collapse Queues and Workers tables