### PR TITLE
Fix: conversão XML unicode para UTF-8 para gerar XML ElementTree

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -87,7 +87,7 @@ class Assets(object):
                 './/supplementary-material[@xlink:href]',
                 './/inline-supplementary-material[@xlink:href]',
             ]
-            xml_et = etree.XML(self.content)
+            xml_et = etree.XML(self.content.encode('utf-8'))
             namespaces = {'xlink': 'http://www.w3.org/1999/xlink'}
             attrib_iters = [
                 xml_et.iterfind(attrib, namespaces=namespaces)

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -44,7 +44,7 @@ class TestAssets(BaseTestCase):
         )
         document = Article(article_json)
         asset = Assets(document)
-        asset.content = """<?xml version="1.0" encoding="utf-8"?>
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
         <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
 			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.tif"/>
@@ -54,6 +54,7 @@ class TestAssets(BaseTestCase):
 			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.tif"/>
 			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.tif"/>
         </article>"""
+        asset.content = unicode(xml_content)
         expected = [
             "1414-431X-bjmbr-1414-431X20176177-gf01.tif",
             "1414-431X-bjmbr-1414-431X20176177-gf02.tif",


### PR DESCRIPTION
Alteração do `Asset. _extract_media()` para fazer a conversão.