### PR TITLE
processamento parcial - coleta de identificadores via DB

### DIFF
--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -223,7 +223,7 @@ MAIL_MAX_EMAILS = None
 MAIL_ASCII_ATTACHMENTS = False
 
 # Processamento parcial:
-DEFAULT_DIFF_SPAN = int(os.environ.get('OPAC_PROC_DEFAULT_DIFF_SPAN_DAYS', 7))
+DEFAULT_DIFF_SPAN = int(os.environ.get('OPAC_PROC_DEFAULT_DIFF_SPAN_DAYS', 30))
 
 # Prometheus settings:
 PROMETHEUS_ENABLED = os.environ.get('OPAC_PROMETHEUS_ENABLED', 'False') == 'True'


### PR DESCRIPTION
- substituindo coleta de identificadores da API Thrift com o adapter para consulta no Banco
- ajustes de processing date e parser de datatimes  somente quando necessário
- aumentando o prazo de dias (no passado) para coleta de identificadores, de 7 para 30 dias