### PR TITLE
Schedulers para recuperação de identificadores

### DIFF
--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -58,6 +58,10 @@ from opac_proc.datastore.identifiers_models import (
     IssueIdModel,
     ArticleIdModel)
 
+from opac_proc.source_sync.sched import SCHED_ID_BY_MODEL_NAME
+from opac_proc.source_sync.utils import MODEL_NAME_LIST
+
+
 app = create_app()
 manager = Manager(app)
 
@@ -496,6 +500,40 @@ def clear_setup_scheduler_queue(queue):
     print u'\n Limpando fila %s' % queue
     clear_setup_scheduler_jobs(queue)
     print u'\n Sem jobs em fila %s!' % queue
+
+
+@manager.command
+@manager.option('-m', '--model', dest='model_name')
+def setup_idsync_scheduler(model_name='all'):
+    models_selected = []
+    if model_name == 'all':
+        models_selected = MODEL_NAME_LIST
+    elif model_name not in MODEL_NAME_LIST:
+        model_options = str(['all'] + MODEL_NAME_LIST)
+        sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
+
+    for model_name_ in models_selected:
+        sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
+        sched_instance = sched_class()
+        print "configurando scheduler na fila: %s para o modelo: %s" % (sched_instance.queue_name, model_name_)
+        sched_instance.setup()
+
+
+@manager.command
+@manager.option('-m', '--model', dest='model_name')
+def clear_idsync_scheduler(model_name='all'):
+    models_selected = []
+    if model_name == 'all':
+        models_selected = MODEL_NAME_LIST
+    elif model_name not in MODEL_NAME_LIST:
+        model_options = str(['all'] + MODEL_NAME_LIST)
+        sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
+
+    for model_name_ in models_selected:
+        sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
+        sched_instance = sched_class()
+        print "limpando scheduler na fila: %s para o modelo: %s" % (sched_instance.queue_name, model_name_)
+        sched_instance.clear_jobs()
 
 
 if __name__ == "__main__":

--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -511,6 +511,8 @@ def setup_idsync_scheduler(model_name='all'):
     elif model_name not in MODEL_NAME_LIST:
         model_options = str(['all'] + MODEL_NAME_LIST)
         sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
+    else:
+        models_selected = [model_name, ]
 
     for model_name_ in models_selected:
         sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
@@ -528,6 +530,8 @@ def clear_idsync_scheduler(model_name='all'):
     elif model_name not in MODEL_NAME_LIST:
         model_options = str(['all'] + MODEL_NAME_LIST)
         sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
+    else:
+        models_selected = [model_name, ]
 
     for model_name_ in models_selected:
         sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]

--- a/opac_proc/source_sync/sched.py
+++ b/opac_proc/source_sync/sched.py
@@ -72,7 +72,7 @@ class SyncScheduler:
             connection=self._redis_conn)
 
     def setup(self):
-        rq_sched = self.get_scheduler_instance()
+        rq_sched = self._rq_scheduler_instance
 
         if self.task_func:
             rq_sched.cron(
@@ -87,7 +87,7 @@ class SyncScheduler:
         return self._rq_scheduler_instance
 
     def clear_jobs(self):
-        rq_sched = self.get_scheduler_instance()
+        rq_sched = self._rq_scheduler_instance
 
         for job in rq_sched.get_jobs():
             if job.origin == self.queue_name:

--- a/opac_proc/source_sync/sched.py
+++ b/opac_proc/source_sync/sched.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+import os
+import logging
+import logging.config
+
+from flask import current_app
+from redis import Redis
+from rq import Queue
+from rq_scheduler import Scheduler
+
+
+logger = logging.getLogger(__name__)
+logger_ini = os.path.join(os.path.dirname(__file__), 'logging.ini')
+logging.config.fileConfig(logger_ini, disable_existing_loggers=False)
+
+
+class SyncScheduler:
+
+    q_names = {
+        'extract': {
+            'collection': 'qex_collections',
+            'journal': 'qex_journals',
+            'issue': 'qex_issues',
+            'article': 'qex_articles',
+            'press_release': 'qex_press_releases',
+            'news': 'qex_news',
+        },
+        'transform': {
+            'collection': 'qtr_collections',
+            'journal': 'qtr_journals',
+            'issue': 'qtr_issues',
+            'article': 'qtr_articles',
+            'press_release': 'qtr_press_releases',
+            'news': 'qtr_news',
+        },
+        'load': {
+            'collection': 'qlo_collections',
+            'journal': 'qlo_journals',
+            'issue': 'qlo_issues',
+            'article': 'qlo_articles',
+            'press_release': 'qlo_press_releases',
+            'news': 'qlo_news',
+        },
+        'sync_ids': {
+            'collection': 'qss_collections',
+            'journal': 'qss_journals',
+            'issue': 'qss_issues',
+            'article': 'qss_articles',
+            'press_release': 'qss_press_releases',
+            'news': 'qss_news',
+        }
+    }
+
+    model_name = ''  # definir na subclasse
+    stage = ''  # definir na subclasse
+    cron_string = None  # definir na subclasse
+    task_func = None  # definir na subclasse
+    task_args = None  # definir na subclasse
+
+    queue_name = None
+    _queue = None
+    _redis_conn = None
+    _rq_scheduler_instance = None
+
+    def __init__(self):
+        self._redis_conn = Redis(**current_app.config['REDIS_SETTINGS'])
+        self.queue_name = self.q_names[self.stage][self.model_name]
+
+        self.queue = Queue(self.queue_name, connection=self._redis_conn)
+        self._rq_scheduler_instance = Scheduler(
+            queue=self._queue,
+            connection=self._redis_conn)
+
+    def setup(self):
+        rq_sched = self.get_scheduler_instance()
+
+        if self.task_func:
+            rq_sched.cron(
+                self.cron_string,
+                func=self.task_func,
+                args=self.task_args,
+                queue_name=self.queue_name)
+        else:
+            raise AttributeError(u'Falta definir a função da task e/ou args')
+
+    def get_scheduler_instance(self):
+        return self._rq_scheduler_instance
+
+    def clear_jobs(self):
+        rq_sched = self.get_scheduler_instance()
+
+        for job in rq_sched.get_jobs():
+            if job.origin == self.queue_name:
+                logger.info('[scheduler: %s]removendo job %s do scheduler' % (
+                    self.model_name, job.id))
+                rq_sched.cancel(job)
+
+
+class CollectionIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'collection'
+    cron_string = '0/30 5-23 * * 3,6'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_collections_identifiers'
+
+
+class JournalIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'journal'
+    cron_string = '0/30 5-23 * * 3,6'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_journals_identifiers'
+
+
+class IssueIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'issue'
+    cron_string = '0/30 5-23 * * 3,6'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_issues_identifiers'
+
+
+class ArticleIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'article'
+    cron_string = '0/30 5-23 * * 3,6'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_articles_identifiers'
+
+
+class PressReleaseIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'press_release'
+    cron_string = '30 * * * *'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_press_releases_identifiers'
+
+
+class NewsIdSyncScheduler(SyncScheduler):
+    stage = 'sync_ids'
+    model_name = 'news'
+    cron_string = '30 * * * *'
+    task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_news_identifiers'
+
+
+SCHED_ID_BY_MODEL_NAME = {
+    'collection': CollectionIdSyncScheduler,
+    'journal': JournalIdSyncScheduler,
+    'issue': IssueIdSyncScheduler,
+    'article': ArticleIdSyncScheduler,
+    'press_release': PressReleaseIdSyncScheduler,
+    'news': NewsIdSyncScheduler,
+}

--- a/opac_proc/web/accounts/templates/accounts/login.html
+++ b/opac_proc/web/accounts/templates/accounts/login.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
 
       {% if current_user.is_authenticated %}
 

--- a/opac_proc/web/accounts/templates/accounts/register.html
+++ b/opac_proc/web/accounts/templates/accounts/register.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
       {% if current_user.is_authenticated %}
 
         <div class="panel panel-default">

--- a/opac_proc/web/accounts/templates/accounts/registration_disabled.html
+++ b/opac_proc/web/accounts/templates/accounts/registration_disabled.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
 
         <div class="panel panel-default">
           <div class="panel-heading">Registro de usuário</div>

--- a/opac_proc/web/accounts/templates/accounts/reset_password.html
+++ b/opac_proc/web/accounts/templates/accounts/reset_password.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
 
       <div class="panel panel-default">
         <div class="panel-heading">Reset Password</div>

--- a/opac_proc/web/accounts/templates/accounts/reset_with_token.html
+++ b/opac_proc/web/accounts/templates/accounts/reset_with_token.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
 
       <div class="panel panel-default">
         <div class="panel-heading">Reset Password</div>

--- a/opac_proc/web/accounts/templates/accounts/unconfirm_email.html
+++ b/opac_proc/web/accounts/templates/accounts/unconfirm_email.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1></h1>
   <div class="row">
-    <div class="col-md-5 col-md-offset-4">
+    <div class="col-md-4 col-md-offset-4">
         <div class="panel panel-warning">
           <div class="panel-heading">Email não confirmado!</div>
           <div class="panel-body">


### PR DESCRIPTION
management commands:

- `python manage.py setup_idsync_scheduler` para instalar os schedulers
- `python manage.py clear_idsync_scheduler` para remover os schedulers

os comandos podem receber o parâmetro: `-m` ou `--model` para indicar o modelo. por padrão vai instalar/remover schedulers para todos os modelos: `collection`, `journal`, `issue`, `article`, `press_release` e `news`.