### PR TITLE
Ajustes na transformação de artigos no tratamento dos ativos digitais

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -97,11 +97,14 @@ class Assets(object):
                 element.attrib['{http://www.w3.org/1999/xlink}href']
                 for element in itertools.chain(*attrib_iters)
             ]
-            extension_files_list = config.PROC_MEDIA_EXTENSION_FILES.split(',')
+            extension_files_list = [
+                '.' + extension
+                for extension in config.MEDIA_EXTENSION_FILES.split(',')
+            ]
             medias = [
                 href
                 for href in hrefs
-                if href.split('.')[-1] in extension_files_list
+                if os.path.splitext(href)[-1] in extension_files_list
             ]
         else:
             parser = "html.parser"
@@ -112,7 +115,7 @@ class Assets(object):
             ]
 
             def _is_external_link(src_tag):
-                ext_link_indicators = config.PROC_MEDIA_EXT_LINKS_IND.split(',')
+                ext_link_indicators = config.MEDIA_EXT_LINKS_IND.split(',')
                 return any(
                     map(lambda ext_link_ind: src_tag.startswith(ext_link_ind),
                         ext_link_indicators)
@@ -131,7 +134,7 @@ class Assets(object):
         Returns the folder path of media.
         """
         asset_path = config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
-        if name.split('.')[-1].lower() == 'pdf':
+        if os.path.splitext(name)[-1].lower() == '.pdf':
             asset_path = config.OPAC_PROC_ASSETS_SOURCE_PDF_PATH
 
         return '%s/%s/%s/%s' % (

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -1,27 +1,29 @@
 # coding: utf-8
-import json
-import urllib2
-
 from bs4 import BeautifulSoup
-from xylose.scielodocument import Article
 
 from base import BaseTestCase
 from opac_proc.core.assets import Assets
+from opac_proc.web import config
 
 
 class TestAssets(BaseTestCase):
 
     def setUp(self):
-        self.am_api_url = 'http://articlemeta.scielo.org/api/v1/article/?code={}&format={}'
+        class MockedXyloseJournal:
+            def __init__(self):
+                self.acronym = 'test'
+
+        class MockedXyloseArticle:
+            def __init__(self):
+                self.journal = MockedXyloseJournal()
+                self.assets_code = '0001-0203'
+                self.data_model_version = 'xml'
+
+        self.mocked_xylose_article = MockedXyloseArticle()
 
     def test_article_transform_html_extract_media(self):
-        article_json = json.loads(
-            urllib2.urlopen(
-                self.am_api_url.format('S0001-37652004000400001', 'json')
-            ).read()
-        )
-        document = Article(article_json)
-        asset = Assets(document)
+        self.mocked_xylose_article.data_model_version = 'html'
+        asset = Assets(self.mocked_xylose_article)
         asset.content = """
         <!-- <img src="/img/revistas/aabc/v76n4/a01img00.gif " /> -->
         <p align="center"><img src="/img/revistas/aabc/v76n4/a01img26.gif " /></p>
@@ -36,14 +38,31 @@ class TestAssets(BaseTestCase):
         self.assertEqual(len(medias), 4)
         self.assertEqual(medias, expected)
 
+    def test_article_transform_html_extract_media_external_links(self):
+        self.mocked_xylose_article.data_model_version = 'html'
+        asset = Assets(self.mocked_xylose_article)
+        asset.content = """
+        <!-- <img src="/img/revistas/aabc/v76n4/a01img00.gif " /> -->
+        <p align="center"><img src="/img/revistas/aabc/v76n4/a01img26.gif " /></p>
+        <p>Here, <img src="/img/revistas/aabc/v76n4/a01img27.gif" align="absmiddle" />
+            <font face="symbol">    \xbc</font>,
+            <img src="https://mail.google.com/mail.gif" align="absmiddle" />
+            <font face="symbol">\xae</font>
+        </p>
+        <p align="center"><img src="/img/revistas/aabc/v76n4/a01img01.gif " /></p>
+        """
+        expected = [
+            "/img/revistas/aabc/v76n4/a01img26.gif",
+            "/img/revistas/aabc/v76n4/a01img27.gif",
+            "/img/revistas/aabc/v76n4/a01img01.gif"
+        ]
+        medias = asset._extract_media()
+        self.assertEqual(len(medias), 3)
+        self.assertEqual(medias, expected)
+
     def test_article_transform_xml_extract_media(self):
-        article_json = json.loads(
-            urllib2.urlopen(
-                self.am_api_url.format('S0100-879X2017001100602', 'json')
-            ).read()
-        )
-        document = Article(article_json)
-        asset = Assets(document)
+        self.mocked_xylose_article.data_model_version = 'xml'
+        asset = Assets(self.mocked_xylose_article)
         xml_content = """<?xml version="1.0" encoding="utf-8"?>
         <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
@@ -67,3 +86,80 @@ class TestAssets(BaseTestCase):
         medias = asset._extract_media()
         self.assertEqual(len(medias), 7)
         self.assertEqual(medias, expected)
+
+    def test_article_transform_xml_extract_media_valid_extensions(self):
+        self.mocked_xylose_article.data_model_version = 'xml'
+        asset = Assets(self.mocked_xylose_article)
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.jpg"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf03.gif"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf04.exe"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf05.xls"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.avi"/>
+			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.csv"/>
+        </article>"""
+        asset.content = unicode(xml_content)
+        expected = [
+            "1414-431X-bjmbr-1414-431X20176177-gf01.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf02.jpg",
+            "1414-431X-bjmbr-1414-431X20176177-gf03.gif",
+            "1414-431X-bjmbr-1414-431X20176177-gf06.avi",
+        ]
+        medias = asset._extract_media()
+        self.assertEqual(len(medias), 4)
+        self.assertEqual(medias, expected)
+
+    def test_normalize_media_path_html_exclude_medias(self):
+        asset = Assets(self.mocked_xylose_article)
+        media_path = '/img/revistas/gs/v29n4/seta.jpg'
+        result = asset._normalize_media_path_html(media_path)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, (media_path, None))
+
+    def test_normalize_media_path_html_tif_to_jpg(self):
+        asset = Assets(self.mocked_xylose_article)
+        media_path = '/img/revistas/gs/v29n4/asset.tif'
+        expected = '%s/gs/v29n4/asset.jpg' % (
+            config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
+        )
+        original_path, new_media_path = \
+            asset._normalize_media_path_html(media_path)
+        self.assertIsNotNone(new_media_path)
+        self.assertEqual(original_path, media_path)
+        self.assertEqual(new_media_path, expected)
+
+    def test_normalize_media_path_html_replace_to_source_media_path(self):
+        asset = Assets(self.mocked_xylose_article)
+        media_path = '/img/fbpe/gs/v29n4/asset.gif'
+        expected = '%s/gs/v29n4/asset.gif' % (
+            config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
+        )
+        original_path, new_media_path = \
+            asset._normalize_media_path_html(media_path)
+        self.assertIsNotNone(new_media_path)
+        self.assertEqual(original_path, media_path)
+        self.assertEqual(new_media_path, expected)
+
+    def test_get_media_path_returns_source_media_path(self):
+        asset = Assets(self.mocked_xylose_article)
+        name = 'asset.jpg'
+        expected = '%s/%s/%s/%s' % (config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH,
+                                    self.mocked_xylose_article.journal.acronym,
+                                    self.mocked_xylose_article.assets_code,
+                                    name)
+        media_path = asset._get_media_path(name)
+        self.assertIsNotNone(media_path)
+        self.assertEqual(media_path, expected)
+
+    def test_get_media_path_returns_source_pdf_path_for_pdf_files(self):
+        asset = Assets(self.mocked_xylose_article)
+        name = 'asset.pdf'
+        expected = '%s/%s/%s/%s' % (config.OPAC_PROC_ASSETS_SOURCE_PDF_PATH,
+                                    self.mocked_xylose_article.journal.acronym,
+                                    self.mocked_xylose_article.assets_code,
+                                    name)
+        media_path = asset._get_media_path(name)
+        self.assertIsNotNone(media_path)
+        self.assertEqual(media_path, expected)

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -196,8 +196,8 @@ OPAC_PROC_ARTICLE_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_CSS_URL', 'https:/
 OPAC_PROC_ARTICLE_PRINT_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_PRINT_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-print.css')
 OPAC_PROC_ARTICLE_JS_URL = os.environ.get('OPAC_PROC_ARTICLE_JS_URL', 'https://ssm.scielo.org/media/assets/js/scielo-article.js')
 
-OPAC_PROC_MEDIA_XML_MATCH_REGEX = os.environ.get('OPAC_PROC_IMG_XML_MATCH_REGEX', 'href="([^/\s]+\.(?:tiff|tif|jpg|jpeg|gif|webp|png|svg|mp3|mp4|wav|wma|avi))"')
-OPAC_PROC_MEDIA_HTML_MATCH_REGEX = os.environ.get('OPAC_PROC_IMG_HTML_MATCH_REGEX', 'src="([^"]+)"')
+PROC_MEDIA_EXTENSION_FILES = os.environ.get('OPAC_PROC_MEDIA_EXTENSION_FILES', 'tiff,tif,jpg,jpeg,gif,webp,png,svg,mp3,mp4,wav,wma,avi')
+PROC_MEDIA_EXT_LINKS_IND = os.environ.get('OPAC_PROC_MEDIA_EXT_LINKS_IND', 'http,ftp,sft,sft')
 OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS = os.environ.get('OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS', '<a href="#top">(.*?)</a>,<a href="#enda">(.*?)</a>,<a href="#up">(.*?)</a>')
 OPAC_PROC_MEDIA_ARROW_REPLACE = os.environ.get('OPAC_PROC_MEDIA_ARROW_REPLACE', '<a href="#top">&#9650;</a>')
 

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -196,8 +196,8 @@ OPAC_PROC_ARTICLE_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_CSS_URL', 'https:/
 OPAC_PROC_ARTICLE_PRINT_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_PRINT_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-print.css')
 OPAC_PROC_ARTICLE_JS_URL = os.environ.get('OPAC_PROC_ARTICLE_JS_URL', 'https://ssm.scielo.org/media/assets/js/scielo-article.js')
 
-PROC_MEDIA_EXTENSION_FILES = os.environ.get('OPAC_PROC_MEDIA_EXTENSION_FILES', 'tiff,tif,jpg,jpeg,gif,webp,png,svg,mp3,mp4,wav,wma,avi')
-PROC_MEDIA_EXT_LINKS_IND = os.environ.get('OPAC_PROC_MEDIA_EXT_LINKS_IND', 'http,ftp,sft,sft')
+MEDIA_EXTENSION_FILES = os.environ.get('OPAC_PROC_MEDIA_EXTENSION_FILES', 'tiff,tif,jpg,jpeg,gif,webp,png,svg,mp3,mp4,wav,wma,avi')
+MEDIA_EXT_LINKS_IND = os.environ.get('OPAC_PROC_MEDIA_EXT_LINKS_IND', 'http,ftp,sft,sft')
 OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS = os.environ.get('OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS', '<a href="#top">(.*?)</a>,<a href="#enda">(.*?)</a>,<a href="#up">(.*?)</a>')
 OPAC_PROC_MEDIA_ARROW_REPLACE = os.environ.get('OPAC_PROC_MEDIA_ARROW_REPLACE', '<a href="#top">&#9650;</a>')
 


### PR DESCRIPTION
Related to #325 e #326 

- Validação das extensões de ativos digitais para artigos em XML
- Validação `src`s de ativos digitais para artigos em HTML, preservando
links externos
- Correção do source path para PDFs para artigos em XML
- Ajustes nas normailizações dos paths dos ativos digitais de artigos
- Testes unitários
