### PR TITLE
add schedulers para produzir e consumir registros de processamento parcial

### DIFF
--- a/opac_proc/core/logging.ini
+++ b/opac_proc/core/logging.ini
@@ -1,0 +1,22 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt=

--- a/opac_proc/core/sched.py
+++ b/opac_proc/core/sched.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+import os
+import sys
+import logging
+import logging.config
+
+from flask import current_app
+from redis import Redis
+from rq import Queue
+from rq_scheduler import Scheduler
+
+
+PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+sys.path.append(PROJECT_PATH)
+
+
+logger = logging.getLogger(__name__)
+logger_ini = os.path.join(os.path.dirname(__file__), 'logging.ini')
+logging.config.fileConfig(logger_ini, disable_existing_loggers=False)
+
+
+class SyncScheduler:
+
+    q_names = {
+        'extract': {
+            'collection': 'qex_collections',
+            'journal': 'qex_journals',
+            'issue': 'qex_issues',
+            'article': 'qex_articles',
+            'press_release': 'qex_press_releases',
+            'news': 'qex_news',
+        },
+        'transform': {
+            'collection': 'qtr_collections',
+            'journal': 'qtr_journals',
+            'issue': 'qtr_issues',
+            'article': 'qtr_articles',
+            'press_release': 'qtr_press_releases',
+            'news': 'qtr_news',
+        },
+        'load': {
+            'collection': 'qlo_collections',
+            'journal': 'qlo_journals',
+            'issue': 'qlo_issues',
+            'article': 'qlo_articles',
+            'press_release': 'qlo_press_releases',
+            'news': 'qlo_news',
+        },
+        'sync_ids': {
+            'collection': 'qss_collections',
+            'journal': 'qss_journals',
+            'issue': 'qss_issues',
+            'article': 'qss_articles',
+            'press_release': 'qss_press_releases',
+            'news': 'qss_news',
+        }
+    }
+
+    model_name = ''  # definir na subclasse
+    stage = ''  # definir na subclasse
+    cron_string = None  # definir na subclasse
+    task_func = None  # definir na subclasse
+    task_args = None  # definir na subclasse
+
+    queue_name = None
+    _queue = None
+    _redis_conn = None
+    _rq_scheduler_instance = None
+
+    def __init__(self):
+        self._redis_conn = Redis(**current_app.config['REDIS_SETTINGS'])
+        self.queue_name = self.q_names[self.stage][self.model_name]
+
+        self.queue = Queue(self.queue_name, connection=self._redis_conn)
+        self._rq_scheduler_instance = Scheduler(
+            queue=self._queue,
+            connection=self._redis_conn)
+
+    def setup(self):
+        rq_sched = self._rq_scheduler_instance
+
+        if self.task_func:
+            rq_sched.cron(
+                self.cron_string,
+                func=self.task_func,
+                args=self.task_args,
+                queue_name=self.queue_name)
+        else:
+            raise AttributeError(u'Falta definir a função da task e/ou args')
+
+    def get_scheduler_instance(self):
+        return self._rq_scheduler_instance
+
+    def clear_jobs(self):
+        rq_sched = self._rq_scheduler_instance
+
+        for job in rq_sched.get_jobs():
+            if job.origin == self.queue_name:
+                logger.info('[scheduler: %s]removendo job %s do scheduler' % (
+                    self.model_name, job.id))
+                rq_sched.cancel(job)

--- a/opac_proc/differs/consumer_sched.py
+++ b/opac_proc/differs/consumer_sched.py
@@ -1,0 +1,463 @@
+# coding: utf-8
+
+from opac_proc.core.sched import SyncScheduler
+
+
+class ConsumeAddDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.consumer_jobs.task_consume_diff_add'
+
+
+class ConsumeUpdateDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.consumer_jobs.task_consume_diff_update'
+
+
+class ConsumeDeleteDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.consumer_jobs.task_consume_diff_delete'
+
+
+# Extract Collection:
+
+
+class ConsumeExtractCollectionAddSched(ConsumeAddDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+class ConsumeExtractCollectionUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+class ConsumeExtractCollectionDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+# Extract Journal:
+
+
+class ConsumeExtractJournalAddSched(ConsumeAddDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+class ConsumeExtractJournalUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+class ConsumeExtractJournalDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+# Extract Issue:
+
+
+class ConsumeExtractIssueAddSched(ConsumeAddDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+class ConsumeExtractIssueUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+class ConsumeExtractIssueDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+# Extract Article:
+
+
+class ConsumeExtractArticleAddSched(ConsumeAddDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+class ConsumeExtractArticleUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+class ConsumeExtractArticleDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+# Extract PressRelease:
+
+
+class ConsumeExtractPressReleaseAddSched(ConsumeAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+class ConsumeExtractPressReleaseUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+class ConsumeExtractPressReleaseDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+# Extract News:
+
+
+class ConsumeExtractNewsAddSched(ConsumeAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+class ConsumeExtractNewsUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+class ConsumeExtractNewsDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+# Transform Collection:
+
+
+class ConsumeTransformCollectionAddSched(ConsumeAddDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+class ConsumeTransformCollectionUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+class ConsumeTransformCollectionDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+# Transform Journal:
+
+
+class ConsumeTransformJournalAddSched(ConsumeAddDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+class ConsumeTransformJournalUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+class ConsumeTransformJournalDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+# Transform Issue:
+
+
+class ConsumeTransformIssueAddSched(ConsumeAddDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+class ConsumeTransformIssueUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+class ConsumeTransformIssueDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+# Transform Article:
+
+
+class ConsumeTransformArticleAddSched(ConsumeAddDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+class ConsumeTransformArticleUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+class ConsumeTransformArticleDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+# Transform PressRelease:
+
+
+class ConsumeTransformPressReleaseAddSched(ConsumeAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+class ConsumeTransformPressReleaseUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+class ConsumeTransformPressReleaseDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+# Transform News:
+
+
+class ConsumeTransformNewsAddSched(ConsumeAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+class ConsumeTransformNewsUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+class ConsumeTransformNewsDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+# Load Collection:
+
+
+class ConsumeLoadCollectionAddSched(ConsumeAddDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+class ConsumeLoadCollectionUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+class ConsumeLoadCollectionDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+# Load Journal:
+
+
+class ConsumeLoadJournalAddSched(ConsumeAddDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+class ConsumeLoadJournalUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+class ConsumeLoadJournalDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+# Load Issue:
+
+
+class ConsumeLoadIssueAddSched(ConsumeAddDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+class ConsumeLoadIssueUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+class ConsumeLoadIssueDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+# Load Article:
+
+
+class ConsumeLoadArticleAddSched(ConsumeAddDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+class ConsumeLoadArticleUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+class ConsumeLoadArticleDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+# Load PressRelease:
+
+
+class ConsumeLoadPressReleaseAddSched(ConsumeAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+class ConsumeLoadPressReleaseUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+class ConsumeLoadPressReleaseDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+# Load News:
+
+
+class ConsumeLoadNewsAddSched(ConsumeAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+class ConsumeLoadNewsUpdateSched(ConsumeUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+class ConsumeLoadNewsDeleteSched(ConsumeDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+CONSUMER_SCHEDS = {
+    'extract': {
+        'collection': {
+            'add': ConsumeExtractCollectionAddSched,
+            'update': ConsumeExtractCollectionUpdateSched,
+            'delete': ConsumeExtractCollectionDeleteSched
+        },
+        'journal': {
+            'add': ConsumeExtractJournalAddSched,
+            'update': ConsumeExtractJournalUpdateSched,
+            'delete': ConsumeExtractJournalDeleteSched
+        },
+        'issue': {
+            'add': ConsumeExtractIssueAddSched,
+            'update': ConsumeExtractIssueUpdateSched,
+            'delete': ConsumeExtractIssueDeleteSched,
+        },
+        'article': {
+            'add': ConsumeExtractArticleAddSched,
+            'update': ConsumeExtractArticleUpdateSched,
+            'delete': ConsumeExtractArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ConsumeExtractPressReleaseAddSched,
+            'update': ConsumeExtractPressReleaseUpdateSched,
+            'delete': ConsumeExtractPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ConsumeExtractNewsAddSched,
+            'update': ConsumeExtractNewsUpdateSched,
+            'delete': ConsumeExtractNewsDeleteSched
+        }
+    },
+    'transform': {
+        'collection': {
+            'add': ConsumeTransformCollectionAddSched,
+            'update': ConsumeTransformCollectionUpdateSched,
+            'delete': ConsumeTransformCollectionDeleteSched
+        },
+        'journal': {
+            'add': ConsumeTransformJournalAddSched,
+            'update': ConsumeTransformJournalUpdateSched,
+            'delete': ConsumeTransformJournalDeleteSched
+        },
+        'issue': {
+            'add': ConsumeTransformIssueAddSched,
+            'update': ConsumeTransformIssueUpdateSched,
+            'delete': ConsumeTransformIssueDeleteSched,
+        },
+        'article': {
+            'add': ConsumeTransformArticleAddSched,
+            'update': ConsumeTransformArticleUpdateSched,
+            'delete': ConsumeTransformArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ConsumeTransformPressReleaseAddSched,
+            'update': ConsumeTransformPressReleaseUpdateSched,
+            'delete': ConsumeTransformPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ConsumeTransformNewsAddSched,
+            'update': ConsumeTransformNewsUpdateSched,
+            'delete': ConsumeTransformNewsDeleteSched
+        }
+    },
+    'load': {
+        'collection': {
+            'add': ConsumeLoadCollectionAddSched,
+            'update': ConsumeLoadCollectionUpdateSched,
+            'delete': ConsumeLoadCollectionDeleteSched
+        },
+        'journal': {
+            'add': ConsumeLoadJournalAddSched,
+            'update': ConsumeLoadJournalUpdateSched,
+            'delete': ConsumeLoadJournalDeleteSched
+        },
+        'issue': {
+            'add': ConsumeLoadIssueAddSched,
+            'update': ConsumeLoadIssueUpdateSched,
+            'delete': ConsumeLoadIssueDeleteSched,
+        },
+        'article': {
+            'add': ConsumeLoadArticleAddSched,
+            'update': ConsumeLoadArticleUpdateSched,
+            'delete': ConsumeLoadArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ConsumeLoadPressReleaseAddSched,
+            'update': ConsumeLoadPressReleaseUpdateSched,
+            'delete': ConsumeLoadPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ConsumeLoadNewsAddSched,
+            'update': ConsumeLoadNewsUpdateSched,
+            'delete': ConsumeLoadNewsDeleteSched
+        }
+    }
+}

--- a/opac_proc/differs/process.py
+++ b/opac_proc/differs/process.py
@@ -14,9 +14,9 @@ class ProcessDiffersBase:
     task_produce_delete = 'opac_proc.differs.produce_jobs.task_produce_diff_delete'
     task_delete_selected = 'opac_proc.differs.produce_jobs.task_delete_selected_diff_etl_model'
     task_delete_all = 'opac_proc.differs.produce_jobs.task_delete_all_diff_etl_model'
-    task_consume_add = 'opac_proc.differs.produce_jobs.task_consume_diff_add'
-    task_consume_update = 'opac_proc.differs.produce_jobs.task_consume_diff_update'
-    task_consume_delete = 'opac_proc.differs.produce_jobs.task_consume_diff_delete'
+    task_consume_add = 'opac_proc.differs.consumer_jobs.task_consume_diff_add'
+    task_consume_update = 'opac_proc.differs.consumer_jobs.task_consume_diff_update'
+    task_consume_delete = 'opac_proc.differs.consumer_jobs.task_consume_diff_delete'
 
     def produce(self, stage, action):
         task_fn = None

--- a/opac_proc/differs/producer_sched.py
+++ b/opac_proc/differs/producer_sched.py
@@ -1,0 +1,463 @@
+# coding: utf-8
+
+from opac_proc.core.sched import SyncScheduler
+
+
+class ProduceAddDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.producer_jobs.task_produce_diff_add'
+
+
+class ProduceUpdateDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.producer_jobs.task_produce_diff_update'
+
+
+class ProduceDeleteDifferBase(SyncScheduler):
+    stage = 'sync_ids'
+    cron_string = '0,30 5-23 * * 3,6'
+    task_func = 'opac_proc.differs.producer_jobs.task_produce_diff_delete'
+
+
+# Extract Collection:
+
+
+class ProduceExtractCollectionAddSched(ProduceAddDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+class ProduceExtractCollectionUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+class ProduceExtractCollectionDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['extract', 'collection']
+
+
+# Extract Journal:
+
+
+class ProduceExtractJournalAddSched(ProduceAddDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+class ProduceExtractJournalUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+class ProduceExtractJournalDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['extract', 'journal']
+
+
+# Extract Issue:
+
+
+class ProduceExtractIssueAddSched(ProduceAddDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+class ProduceExtractIssueUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+class ProduceExtractIssueDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['extract', 'issue']
+
+
+# Extract Article:
+
+
+class ProduceExtractArticleAddSched(ProduceAddDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+class ProduceExtractArticleUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+class ProduceExtractArticleDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['extract', 'article']
+
+
+# Extract PressRelease:
+
+
+class ProduceExtractPressReleaseAddSched(ProduceAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+class ProduceExtractPressReleaseUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+class ProduceExtractPressReleaseDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'press_release']
+
+
+# Extract News:
+
+
+class ProduceExtractNewsAddSched(ProduceAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+class ProduceExtractNewsUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+class ProduceExtractNewsDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['extract', 'news']
+
+
+# Transform Collection:
+
+
+class ProduceTransformCollectionAddSched(ProduceAddDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+class ProduceTransformCollectionUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+class ProduceTransformCollectionDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['transform', 'collection']
+
+
+# Transform Journal:
+
+
+class ProduceTransformJournalAddSched(ProduceAddDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+class ProduceTransformJournalUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+class ProduceTransformJournalDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['transform', 'journal']
+
+
+# Transform Issue:
+
+
+class ProduceTransformIssueAddSched(ProduceAddDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+class ProduceTransformIssueUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+class ProduceTransformIssueDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['transform', 'issue']
+
+
+# Transform Article:
+
+
+class ProduceTransformArticleAddSched(ProduceAddDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+class ProduceTransformArticleUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+class ProduceTransformArticleDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['transform', 'article']
+
+
+# Transform PressRelease:
+
+
+class ProduceTransformPressReleaseAddSched(ProduceAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+class ProduceTransformPressReleaseUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+class ProduceTransformPressReleaseDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'press_release']
+
+
+# Transform News:
+
+
+class ProduceTransformNewsAddSched(ProduceAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+class ProduceTransformNewsUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+class ProduceTransformNewsDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['transform', 'news']
+
+
+# Load Collection:
+
+
+class ProduceLoadCollectionAddSched(ProduceAddDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+class ProduceLoadCollectionUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+class ProduceLoadCollectionDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'collection'
+    task_args = ['load', 'collection']
+
+
+# Load Journal:
+
+
+class ProduceLoadJournalAddSched(ProduceAddDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+class ProduceLoadJournalUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+class ProduceLoadJournalDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'journal'
+    task_args = ['load', 'journal']
+
+
+# Load Issue:
+
+
+class ProduceLoadIssueAddSched(ProduceAddDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+class ProduceLoadIssueUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+class ProduceLoadIssueDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'issue'
+    task_args = ['load', 'issue']
+
+
+# Load Article:
+
+
+class ProduceLoadArticleAddSched(ProduceAddDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+class ProduceLoadArticleUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+class ProduceLoadArticleDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'article'
+    task_args = ['load', 'article']
+
+
+# Load PressRelease:
+
+
+class ProduceLoadPressReleaseAddSched(ProduceAddDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+class ProduceLoadPressReleaseUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+class ProduceLoadPressReleaseDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'press_release'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'press_release']
+
+
+# Load News:
+
+
+class ProduceLoadNewsAddSched(ProduceAddDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+class ProduceLoadNewsUpdateSched(ProduceUpdateDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+class ProduceLoadNewsDeleteSched(ProduceDeleteDifferBase):
+    model_name = 'news'
+    cron_string = '0,30 * * * *'
+    task_args = ['load', 'news']
+
+
+PRODUCER_SCHEDS = {
+    'extract': {
+        'collection': {
+            'add': ProduceExtractCollectionAddSched,
+            'update': ProduceExtractCollectionUpdateSched,
+            'delete': ProduceExtractCollectionDeleteSched
+        },
+        'journal': {
+            'add': ProduceExtractJournalAddSched,
+            'update': ProduceExtractJournalUpdateSched,
+            'delete': ProduceExtractJournalDeleteSched
+        },
+        'issue': {
+            'add': ProduceExtractIssueAddSched,
+            'update': ProduceExtractIssueUpdateSched,
+            'delete': ProduceExtractIssueDeleteSched,
+        },
+        'article': {
+            'add': ProduceExtractArticleAddSched,
+            'update': ProduceExtractArticleUpdateSched,
+            'delete': ProduceExtractArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ProduceExtractPressReleaseAddSched,
+            'update': ProduceExtractPressReleaseUpdateSched,
+            'delete': ProduceExtractPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ProduceExtractNewsAddSched,
+            'update': ProduceExtractNewsUpdateSched,
+            'delete': ProduceExtractNewsDeleteSched
+        }
+    },
+    'transform': {
+        'collection': {
+            'add': ProduceTransformCollectionAddSched,
+            'update': ProduceTransformCollectionUpdateSched,
+            'delete': ProduceTransformCollectionDeleteSched
+        },
+        'journal': {
+            'add': ProduceTransformJournalAddSched,
+            'update': ProduceTransformJournalUpdateSched,
+            'delete': ProduceTransformJournalDeleteSched
+        },
+        'issue': {
+            'add': ProduceTransformIssueAddSched,
+            'update': ProduceTransformIssueUpdateSched,
+            'delete': ProduceTransformIssueDeleteSched,
+        },
+        'article': {
+            'add': ProduceTransformArticleAddSched,
+            'update': ProduceTransformArticleUpdateSched,
+            'delete': ProduceTransformArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ProduceTransformPressReleaseAddSched,
+            'update': ProduceTransformPressReleaseUpdateSched,
+            'delete': ProduceTransformPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ProduceTransformNewsAddSched,
+            'update': ProduceTransformNewsUpdateSched,
+            'delete': ProduceTransformNewsDeleteSched
+        }
+    },
+    'load': {
+        'collection': {
+            'add': ProduceLoadCollectionAddSched,
+            'update': ProduceLoadCollectionUpdateSched,
+            'delete': ProduceLoadCollectionDeleteSched
+        },
+        'journal': {
+            'add': ProduceLoadJournalAddSched,
+            'update': ProduceLoadJournalUpdateSched,
+            'delete': ProduceLoadJournalDeleteSched
+        },
+        'issue': {
+            'add': ProduceLoadIssueAddSched,
+            'update': ProduceLoadIssueUpdateSched,
+            'delete': ProduceLoadIssueDeleteSched,
+        },
+        'article': {
+            'add': ProduceLoadArticleAddSched,
+            'update': ProduceLoadArticleUpdateSched,
+            'delete': ProduceLoadArticleDeleteSched,
+        },
+        'press_release': {
+            'add': ProduceLoadPressReleaseAddSched,
+            'update': ProduceLoadPressReleaseUpdateSched,
+            'delete': ProduceLoadPressReleaseDeleteSched
+        },
+        'news': {
+            'add': ProduceLoadNewsAddSched,
+            'update': ProduceLoadNewsUpdateSched,
+            'delete': ProduceLoadNewsDeleteSched
+        }
+    }
+}

--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -68,6 +68,11 @@ from opac_proc.differs.utils import (
     ACTION_LIST
 )
 
+from opac_proc.utils import (
+    clean_idsync_scheduler_params,
+    clean_differ_scheduler_params
+)
+
 app = create_app()
 manager = Manager(app)
 
@@ -511,15 +516,13 @@ def clear_setup_scheduler_queue(queue):
 @manager.command
 @manager.option('-m', '--model', dest='model_name')
 def setup_idsync_scheduler(model_name='all'):
-    models_selected = []
-    if model_name == 'all':
-        models_selected = MODEL_NAME_LIST
-    elif model_name not in MODEL_NAME_LIST:
-        model_options = str(['all'] + MODEL_NAME_LIST)
-        sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
-    else:
-        models_selected = [model_name, ]
+    """
+    Instala os schedulers para recuperar os identificadores do modelo indicado
+    pelo param model_name.
+    Por padrão será executado para todos os modelos
+    """
 
+    models_selected = clean_idsync_scheduler_params(model_name)
     for model_name_ in models_selected:
         sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
         sched_instance = sched_class()
@@ -530,15 +533,13 @@ def setup_idsync_scheduler(model_name='all'):
 @manager.command
 @manager.option('-m', '--model', dest='model_name')
 def clear_idsync_scheduler(model_name='all'):
-    models_selected = []
-    if model_name == 'all':
-        models_selected = MODEL_NAME_LIST
-    elif model_name not in MODEL_NAME_LIST:
-        model_options = str(['all'] + MODEL_NAME_LIST)
-        sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
-    else:
-        models_selected = [model_name, ]
+    """
+    Removo todos os jobs enfilerados na fila dos schedulers
+    indicados pelos param model_name.
+    Por padrão será executado para todos os modelos
+    """
 
+    models_selected = clean_idsync_scheduler_params(model_name)
     for model_name_ in models_selected:
         sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
         sched_instance = sched_class()
@@ -551,28 +552,12 @@ def clear_idsync_scheduler(model_name='all'):
 @manager.option('-m', '--model', dest='model_name')
 @manager.option('-a', '--action', dest='action')
 def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
-
-    if stage == 'all':
-        stages_list = ETL_STAGE_LIST
-    elif stage not in ETL_STAGE_LIST:
-        sys.exit('Param: stage: %s com valor inesperado!' % stage)
-    else:
-        stages_list = [stage, ]
-
-    if model_name == 'all':
-        models_list = ETL_MODEL_NAME_LIST
-    elif model_name not in ETL_MODEL_NAME_LIST:
-        sys.exit('Param: model: %s com valor inesperado!' % model_name)
-    else:
-        models_list = [model_name]
-
-    if action == 'all':
-        actions_list = ACTION_LIST
-    elif action not in ACTION_LIST:
-        sys.exit('Param: action: %s com valor inesperado!' % action)
-    else:
-        actions_list = [action, ]
-
+    """
+    instala os schedulers para producir a diferencia nos modelos de ETL.
+    Por padrão aplica para todas as fases, todos os modelos e todas as açoes
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        stage, model_name, action)
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:
@@ -588,28 +573,12 @@ def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
 @manager.option('-m', '--model', dest='model_name')
 @manager.option('-a', '--action', dest='action')
 def clear_produce_differ_scheduler(stage='all', model_name='all', action='all'):
-
-    if stage == 'all':
-        stages_list = ETL_STAGE_LIST
-    elif stage not in ETL_STAGE_LIST:
-        sys.exit('Param: stage: %s com valor inesperado!' % stage)
-    else:
-        stages_list = [stage, ]
-
-    if model_name == 'all':
-        models_list = ETL_MODEL_NAME_LIST
-    elif model_name not in ETL_MODEL_NAME_LIST:
-        sys.exit('Param: model: %s com valor inesperado!' % model_name)
-    else:
-        models_list = [model_name]
-
-    if action == 'all':
-        actions_list = ACTION_LIST
-    elif action not in ACTION_LIST:
-        sys.exit('Param: action: %s com valor inesperado!' % action)
-    else:
-        actions_list = [action, ]
-
+    """
+    remove os jobs enfilerados nas filas usadas pelos schedulers de
+    producir as diferencias
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        stage, model_name, action)
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:
@@ -625,28 +594,12 @@ def clear_produce_differ_scheduler(stage='all', model_name='all', action='all'):
 @manager.option('-m', '--model', dest='model_name')
 @manager.option('-a', '--action', dest='action')
 def setup_consume_differ_scheduler(stage='all', model_name='all', action='all'):
-
-    if stage == 'all':
-        stages_list = ETL_STAGE_LIST
-    elif stage not in ETL_STAGE_LIST:
-        sys.exit('Param: stage: %s com valor inesperado!' % stage)
-    else:
-        stages_list = [stage, ]
-
-    if model_name == 'all':
-        models_list = ETL_MODEL_NAME_LIST
-    elif model_name not in ETL_MODEL_NAME_LIST:
-        sys.exit('Param: model: %s com valor inesperado!' % model_name)
-    else:
-        models_list = [model_name]
-
-    if action == 'all':
-        actions_list = ACTION_LIST
-    elif action not in ACTION_LIST:
-        sys.exit('Param: action: %s com valor inesperado!' % action)
-    else:
-        actions_list = [action, ]
-
+    """
+    instala os schedulers para consumir a diferencia nos modelos de ETL.
+    Por padrão aplica para todas as fases, todos os modelos e todas as açoes
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        stage, model_name, action)
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:
@@ -662,28 +615,12 @@ def setup_consume_differ_scheduler(stage='all', model_name='all', action='all'):
 @manager.option('-m', '--model', dest='model_name')
 @manager.option('-a', '--action', dest='action')
 def clear_consume_differ_scheduler(stage='all', model_name='all', action='all'):
-
-    if stage == 'all':
-        stages_list = ETL_STAGE_LIST
-    elif stage not in ETL_STAGE_LIST:
-        sys.exit('Param: stage: %s com valor inesperado!' % stage)
-    else:
-        stages_list = [stage, ]
-
-    if model_name == 'all':
-        models_list = ETL_MODEL_NAME_LIST
-    elif model_name not in ETL_MODEL_NAME_LIST:
-        sys.exit('Param: model: %s com valor inesperado!' % model_name)
-    else:
-        models_list = [model_name]
-
-    if action == 'all':
-        actions_list = ACTION_LIST
-    elif action not in ACTION_LIST:
-        sys.exit('Param: action: %s com valor inesperado!' % action)
-    else:
-        actions_list = [action, ]
-
+    """
+    remove os jobs enfilerados nas filas usadas pelos schedulers de
+    consumir as diferencias
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        stage, model_name, action)
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:

--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -60,7 +60,13 @@ from opac_proc.datastore.identifiers_models import (
 
 from opac_proc.source_sync.sched import SCHED_ID_BY_MODEL_NAME
 from opac_proc.source_sync.utils import MODEL_NAME_LIST
-
+from opac_proc.differs.producer_sched import PRODUCER_SCHEDS
+from opac_proc.differs.consumer_sched import CONSUMER_SCHEDS
+from opac_proc.differs.utils import (
+    ETL_STAGE_LIST,
+    ETL_MODEL_NAME_LIST,
+    ACTION_LIST
+)
 
 app = create_app()
 manager = Manager(app)
@@ -517,7 +523,7 @@ def setup_idsync_scheduler(model_name='all'):
     for model_name_ in models_selected:
         sched_class = SCHED_ID_BY_MODEL_NAME[model_name_]
         sched_instance = sched_class()
-        print "configurando scheduler na fila: %s para o modelo: %s" % (sched_instance.queue_name, model_name_)
+        print "instalando scheduler na fila: %s para o modelo: %s" % (sched_instance.queue_name, model_name_)
         sched_instance.setup()
 
 
@@ -538,6 +544,154 @@ def clear_idsync_scheduler(model_name='all'):
         sched_instance = sched_class()
         print "limpando scheduler na fila: %s para o modelo: %s" % (sched_instance.queue_name, model_name_)
         sched_instance.clear_jobs()
+
+
+@manager.command
+@manager.option('-s', '--stage', dest='stage')
+@manager.option('-m', '--model', dest='model_name')
+@manager.option('-a', '--action', dest='action')
+def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
+
+    if stage == 'all':
+        stages_list = ETL_STAGE_LIST
+    elif stage not in ETL_STAGE_LIST:
+        sys.exit('Param: stage: %s com valor inesperado!' % stage)
+    else:
+        stages_list = [stage, ]
+
+    if model_name == 'all':
+        models_list = ETL_MODEL_NAME_LIST
+    elif model_name not in ETL_MODEL_NAME_LIST:
+        sys.exit('Param: model: %s com valor inesperado!' % model_name)
+    else:
+        models_list = [model_name]
+
+    if action == 'all':
+        actions_list = ACTION_LIST
+    elif action not in ACTION_LIST:
+        sys.exit('Param: action: %s com valor inesperado!' % action)
+    else:
+        actions_list = [action, ]
+
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                sched_class = PRODUCER_SCHEDS[stage_][model_][action_]
+                sched_instance = sched_class()
+                print "[%s][%s][%s] instalando scheduler na fila: %s" % (
+                    stage_, model_, action_, sched_instance.queue_name)
+                sched_instance.setup()
+
+
+@manager.command
+@manager.option('-s', '--stage', dest='stage')
+@manager.option('-m', '--model', dest='model_name')
+@manager.option('-a', '--action', dest='action')
+def clear_produce_differ_scheduler(stage='all', model_name='all', action='all'):
+
+    if stage == 'all':
+        stages_list = ETL_STAGE_LIST
+    elif stage not in ETL_STAGE_LIST:
+        sys.exit('Param: stage: %s com valor inesperado!' % stage)
+    else:
+        stages_list = [stage, ]
+
+    if model_name == 'all':
+        models_list = ETL_MODEL_NAME_LIST
+    elif model_name not in ETL_MODEL_NAME_LIST:
+        sys.exit('Param: model: %s com valor inesperado!' % model_name)
+    else:
+        models_list = [model_name]
+
+    if action == 'all':
+        actions_list = ACTION_LIST
+    elif action not in ACTION_LIST:
+        sys.exit('Param: action: %s com valor inesperado!' % action)
+    else:
+        actions_list = [action, ]
+
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                sched_class = PRODUCER_SCHEDS[stage_][model_][action_]
+                sched_instance = sched_class()
+                print "[%s][%s][%s] limpando scheduler na fila: %s" % (
+                    stage_, model_, action_, sched_instance.queue_name)
+                sched_instance.clear_jobs()
+
+
+@manager.command
+@manager.option('-s', '--stage', dest='stage')
+@manager.option('-m', '--model', dest='model_name')
+@manager.option('-a', '--action', dest='action')
+def setup_consume_differ_scheduler(stage='all', model_name='all', action='all'):
+
+    if stage == 'all':
+        stages_list = ETL_STAGE_LIST
+    elif stage not in ETL_STAGE_LIST:
+        sys.exit('Param: stage: %s com valor inesperado!' % stage)
+    else:
+        stages_list = [stage, ]
+
+    if model_name == 'all':
+        models_list = ETL_MODEL_NAME_LIST
+    elif model_name not in ETL_MODEL_NAME_LIST:
+        sys.exit('Param: model: %s com valor inesperado!' % model_name)
+    else:
+        models_list = [model_name]
+
+    if action == 'all':
+        actions_list = ACTION_LIST
+    elif action not in ACTION_LIST:
+        sys.exit('Param: action: %s com valor inesperado!' % action)
+    else:
+        actions_list = [action, ]
+
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                sched_class = CONSUMER_SCHEDS[stage_][model_][action_]
+                sched_instance = sched_class()
+                print "[%s][%s][%s] instalando scheduler na fila: %s" % (
+                    stage_, model_, action_, sched_instance.queue_name)
+                sched_instance.setup()
+
+
+@manager.command
+@manager.option('-s', '--stage', dest='stage')
+@manager.option('-m', '--model', dest='model_name')
+@manager.option('-a', '--action', dest='action')
+def clear_consume_differ_scheduler(stage='all', model_name='all', action='all'):
+
+    if stage == 'all':
+        stages_list = ETL_STAGE_LIST
+    elif stage not in ETL_STAGE_LIST:
+        sys.exit('Param: stage: %s com valor inesperado!' % stage)
+    else:
+        stages_list = [stage, ]
+
+    if model_name == 'all':
+        models_list = ETL_MODEL_NAME_LIST
+    elif model_name not in ETL_MODEL_NAME_LIST:
+        sys.exit('Param: model: %s com valor inesperado!' % model_name)
+    else:
+        models_list = [model_name]
+
+    if action == 'all':
+        actions_list = ACTION_LIST
+    elif action not in ACTION_LIST:
+        sys.exit('Param: action: %s com valor inesperado!' % action)
+    else:
+        actions_list = [action, ]
+
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                sched_class = CONSUMER_SCHEDS[stage_][model_][action_]
+                sched_instance = sched_class()
+                print "[%s][%s][%s] limpando scheduler na fila: %s" % (
+                    stage_, model_, action_, sched_instance.queue_name)
+                sched_instance.clear_jobs()
 
 
 if __name__ == "__main__":

--- a/opac_proc/source_sync/sched.py
+++ b/opac_proc/source_sync/sched.py
@@ -1,140 +1,47 @@
 # coding: utf-8
-import os
-import logging
-import logging.config
 
-from flask import current_app
-from redis import Redis
-from rq import Queue
-from rq_scheduler import Scheduler
-
-
-logger = logging.getLogger(__name__)
-logger_ini = os.path.join(os.path.dirname(__file__), 'logging.ini')
-logging.config.fileConfig(logger_ini, disable_existing_loggers=False)
-
-
-class SyncScheduler:
-
-    q_names = {
-        'extract': {
-            'collection': 'qex_collections',
-            'journal': 'qex_journals',
-            'issue': 'qex_issues',
-            'article': 'qex_articles',
-            'press_release': 'qex_press_releases',
-            'news': 'qex_news',
-        },
-        'transform': {
-            'collection': 'qtr_collections',
-            'journal': 'qtr_journals',
-            'issue': 'qtr_issues',
-            'article': 'qtr_articles',
-            'press_release': 'qtr_press_releases',
-            'news': 'qtr_news',
-        },
-        'load': {
-            'collection': 'qlo_collections',
-            'journal': 'qlo_journals',
-            'issue': 'qlo_issues',
-            'article': 'qlo_articles',
-            'press_release': 'qlo_press_releases',
-            'news': 'qlo_news',
-        },
-        'sync_ids': {
-            'collection': 'qss_collections',
-            'journal': 'qss_journals',
-            'issue': 'qss_issues',
-            'article': 'qss_articles',
-            'press_release': 'qss_press_releases',
-            'news': 'qss_news',
-        }
-    }
-
-    model_name = ''  # definir na subclasse
-    stage = ''  # definir na subclasse
-    cron_string = None  # definir na subclasse
-    task_func = None  # definir na subclasse
-    task_args = None  # definir na subclasse
-
-    queue_name = None
-    _queue = None
-    _redis_conn = None
-    _rq_scheduler_instance = None
-
-    def __init__(self):
-        self._redis_conn = Redis(**current_app.config['REDIS_SETTINGS'])
-        self.queue_name = self.q_names[self.stage][self.model_name]
-
-        self.queue = Queue(self.queue_name, connection=self._redis_conn)
-        self._rq_scheduler_instance = Scheduler(
-            queue=self._queue,
-            connection=self._redis_conn)
-
-    def setup(self):
-        rq_sched = self._rq_scheduler_instance
-
-        if self.task_func:
-            rq_sched.cron(
-                self.cron_string,
-                func=self.task_func,
-                args=self.task_args,
-                queue_name=self.queue_name)
-        else:
-            raise AttributeError(u'Falta definir a função da task e/ou args')
-
-    def get_scheduler_instance(self):
-        return self._rq_scheduler_instance
-
-    def clear_jobs(self):
-        rq_sched = self._rq_scheduler_instance
-
-        for job in rq_sched.get_jobs():
-            if job.origin == self.queue_name:
-                logger.info('[scheduler: %s]removendo job %s do scheduler' % (
-                    self.model_name, job.id))
-                rq_sched.cancel(job)
+from opac_proc.core.sched import SyncScheduler
 
 
 class CollectionIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'collection'
-    cron_string = '0/30 5-23 * * 3,6'
+    cron_string = '0,30 5-23 * * 3,6'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_collections_identifiers'
 
 
 class JournalIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'journal'
-    cron_string = '0/30 5-23 * * 3,6'
+    cron_string = '0,30 5-23 * * 3,6'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_journals_identifiers'
 
 
 class IssueIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'issue'
-    cron_string = '0/30 5-23 * * 3,6'
+    cron_string = '0,30 5-23 * * 3,6'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_issues_identifiers'
 
 
 class ArticleIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'article'
-    cron_string = '0/30 5-23 * * 3,6'
+    cron_string = '0,30 5-23 * * 3,6'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_articles_identifiers'
 
 
 class PressReleaseIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'press_release'
-    cron_string = '30 * * * *'
+    cron_string = '0,30 * * * *'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_press_releases_identifiers'
 
 
 class NewsIdSyncScheduler(SyncScheduler):
     stage = 'sync_ids'
     model_name = 'news'
-    cron_string = '30 * * * *'
+    cron_string = '0,30 * * * *'
     task_func = 'opac_proc.source_sync.jobs.task_retrieve_all_news_identifiers'
 
 

--- a/opac_proc/utils.py
+++ b/opac_proc/utils.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+import sys
+from opac_proc.source_sync.utils import MODEL_NAME_LIST
+from opac_proc.differs.utils import (
+    ETL_STAGE_LIST,
+    ETL_MODEL_NAME_LIST,
+    ACTION_LIST
+)
+
+
+def clean_idsync_scheduler_params(model_name):
+    """
+    Valida que o parametro: model_name seja valido.
+    Valores válidos são: 'all' ou os itens da lista
+    MODEL_NAME_LIST.
+
+    Quando o model_name é valido, retorna o valor esperado
+    Quando não, executa um sys.exit com a mensagem do
+    erro para o usuário
+    """
+    models_selected = []
+    if model_name == 'all':
+        models_selected = MODEL_NAME_LIST
+    elif model_name not in MODEL_NAME_LIST:
+        model_options = str(['all'] + MODEL_NAME_LIST)
+        sys.exit(u'Modelo "%s" inválido. Opções: "all",%s ' % model_name, model_options)
+    else:
+        models_selected = [model_name, ]
+    return models_selected
+
+
+def clean_differ_scheduler_params(stage, model_name, action):
+    """
+    Valida que os parametros: stage, model_name, action sejam validos.
+    Valores válidos são: 'all' ou os itens da lista
+    ETL_STAGE_LIST, MODEL_NAME_LIST e ACTION_LIST respectivamente.
+
+    Quando um parametro é valido, retorna o valor esperado
+    Quando não, executa um sys.exit com a mensagem do
+    erro para o usuário
+    """
+
+    if stage == 'all':
+        stages_list = ETL_STAGE_LIST
+    elif stage not in ETL_STAGE_LIST:
+        sys.exit('Param: stage: %s com valor inesperado!' % stage)
+    else:
+        stages_list = [stage, ]
+
+    if model_name == 'all':
+        models_list = ETL_MODEL_NAME_LIST
+    elif model_name not in ETL_MODEL_NAME_LIST:
+        sys.exit('Param: model: %s com valor inesperado!' % model_name)
+    else:
+        models_list = [model_name]
+
+    if action == 'all':
+        actions_list = ACTION_LIST
+    elif action not in ACTION_LIST:
+        sys.exit('Param: action: %s com valor inesperado!' % action)
+    else:
+        actions_list = [action, ]
+
+    return (stages_list, models_list, actions_list)

--- a/start_scheduler.sh
+++ b/start_scheduler.sh
@@ -4,6 +4,15 @@ export WORKER_PATH="/app/"
 
 python $WORKER_PATH/opac_proc/manage.py setup_static_catalog_scheduler --all
 
+# iniciamos todos os schedulers para ATUALIZAR identifiers de todos os modelos:
+python $WORKER_PATH/opac_proc/manage.py setup_idsync_scheduler
+
+# iniciamos todos os schedulers para PRODUCIR diffs de todos os modelos de todas as fases de todas as ações:
+python $WORKER_PATH/opac_proc/manage.py setup_produce_differ_scheduler
+
+# iniciamos todos os schedulers para CONSUMIR diffs de todos os modelos de todas as fases de todas as ações:
+python $WORKER_PATH/opac_proc/manage.py setup_consume_differ_scheduler
+
 rqscheduler \
     --url=$REDIS_URL \
     --path=$WORKER_PATH \


### PR DESCRIPTION
- movendo classe: `SyncScheduler` para core/sched.py
- `producer_sched.py` tem as classes especificas de cada scheduler que
producem a diff para cada fasse para cada modelo para cada ação
- `consumer_sched.py` tem as classes especificas de cada scheduler que
consomem a diff para cada fasse para cada modelo para cada ação
- adicionado no `manage.py` os comandos para setup e clear de schedulers
- fix na class differ.process@ProcessDiffersbase que apontava nos
caminhos errados para as task de consumo
- fix nas strings de cron, que não rodabam de 30 em 30, só no minuto 30
- add management commnads no `start_scheduler.sh` para fazer setup de
todos os schedulers quando iniciar o container