### PR TITLE
FIX: schedulers agendados multiplas vezes e add param timeout

### DIFF
--- a/opac_proc/core/sched.py
+++ b/opac_proc/core/sched.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import os
-import sys
 import logging
 import logging.config
 
@@ -9,9 +8,7 @@ from redis import Redis
 from rq import Queue
 from rq_scheduler import Scheduler
 
-
-PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
-sys.path.append(PROJECT_PATH)
+from opac_proc.web.config import DEFAULT_SCHEDULER_TIMEOUT
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +58,7 @@ class SyncScheduler:
     cron_string = None  # definir na subclasse
     task_func = None  # definir na subclasse
     task_args = None  # definir na subclasse
-
+    timeout = DEFAULT_SCHEDULER_TIMEOUT
     queue_name = None
     _queue = None
     _redis_conn = None
@@ -84,7 +81,8 @@ class SyncScheduler:
                 self.cron_string,
                 func=self.task_func,
                 args=self.task_args,
-                queue_name=self.queue_name)
+                queue_name=self.queue_name,
+                timeout=self.timeout)
         else:
             raise AttributeError(u'Falta definir a função da task e/ou args')
 

--- a/opac_proc/core/tasks.py
+++ b/opac_proc/core/tasks.py
@@ -4,6 +4,7 @@ from flask import current_app
 from redis import Redis
 from rq import Queue
 from rq_scheduler import Scheduler
+from opac_proc.web.config import DEFAULT_SCHEDULER_TIMEOUT
 
 
 def get_scheduler(queue_name):
@@ -19,7 +20,8 @@ def setup_scheduler_jobs(task_function, function_args, queue_name,
         cron_string,
         func=task_function,
         args=function_args,
-        queue_name=queue_name)
+        queue_name=queue_name,
+        timeout=DEFAULT_SCHEDULER_TIMEOUT)
 
 
 def clear_setup_scheduler_jobs(queue_name):

--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -631,5 +631,42 @@ def clear_consume_differ_scheduler(stage='all', model_name='all', action='all'):
                 sched_instance.clear_jobs()
 
 
+@manager.command
+def clear_and_setup_all_schedulers():
+    """
+    Comando utilitario para limpar todas filas usadas pelos schedulers e
+    instalar todos os schedulers.
+    """
+    # qxml_catalog e qpdf_catalog
+    print('[limpando] filas de schedulers do catalog')
+    catalog_queues = ['qxml_catalog', 'qpdf_catalog']
+    for queue_name in catalog_queues:
+        clear_setup_scheduler_queue(queue_name)
+
+    # qss_* para identificadores
+    print('[limpando] filas de schedulers do identificadores')
+    clear_idsync_scheduler()
+
+    # qss_* para produzir diff
+    print('[limpando] filas de schedulers do produce diff')
+    clear_produce_differ_scheduler()
+
+    # qss_* para consumir diff
+    print('[limpando] filas de schedulers do consume diff')
+    clear_consume_differ_scheduler()
+
+    print('[instalando] schedulers do catalog')
+    setup_static_catalog_scheduler(all_formats=True)
+
+    print('[instalando] schedulers do identificadores')
+    setup_idsync_scheduler()
+
+    print('[instalando] schedulers do produzir a diff')
+    setup_produce_differ_scheduler()
+
+    print('[instalando] schedulers do consumir a diff')
+    setup_consume_differ_scheduler()
+
+
 if __name__ == "__main__":
     manager.run()

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -239,3 +239,4 @@ PDF_CATALOG_CRON_STRING = os.environ.get('OPAC_PROC_PDF_CATALOG_CRON_STRING',
                                          '0 0 * * 0')
 XML_CATALOG_CRON_STRING = os.environ.get('OPAC_PROC_XML_CATALOG_CRON_STRING',
                                          '0 0 * * 0')
+DEFAULT_SCHEDULER_TIMEOUT = int(os.environ.get('OPAC_PROC_DEFAULT_SCHEDULER_TIMEOUT', 2000))

--- a/start_scheduler.sh
+++ b/start_scheduler.sh
@@ -2,16 +2,8 @@
 export REDIS_URL=redis://$OPAC_PROC_REDIS_HOST:$OPAC_PROC_REDIS_PORT/0
 export WORKER_PATH="/app/"
 
-python $WORKER_PATH/opac_proc/manage.py setup_static_catalog_scheduler --all
-
-# iniciamos todos os schedulers para ATUALIZAR identifiers de todos os modelos:
-python $WORKER_PATH/opac_proc/manage.py setup_idsync_scheduler
-
-# iniciamos todos os schedulers para PRODUCIR diffs de todos os modelos de todas as fases de todas as ações:
-python $WORKER_PATH/opac_proc/manage.py setup_produce_differ_scheduler
-
-# iniciamos todos os schedulers para CONSUMIR diffs de todos os modelos de todas as fases de todas as ações:
-python $WORKER_PATH/opac_proc/manage.py setup_consume_differ_scheduler
+# limpamos as filas de scheduler e instalamos de novo todos os schedulers
+python $WORKER_PATH/opac_proc/manage.py clear_and_setup_all_schedulers
 
 rqscheduler \
     --url=$REDIS_URL \


### PR DESCRIPTION
- aumenta o timeout dos jobs nos schedulers de 180 seg para 2000 seg
- valor do timeout (em segundos) agora é configurável
- add de timout para os schedulers que geram os arquivos de catálogos (tinha sido ajustado só no spa-master)
- novo comando no manage.py `clear_and_setup_all_schedulers` para zerar e instalar todos os schedulers de uma vez. evitando assim que os jobs sejam registrados no redis mais de uma vez.