### PR TITLE
Reestruturação da classe AssetXML e ajuste em configuração

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ dev_compose_up: get_opac_mongo_info get_opac_grpc_info
 	@docker-compose -f $(COMPOSE_FILE_DEV) up -d
 
 dev_compose_logs: get_opac_mongo_info get_opac_grpc_info
-	@docker-compose -f $(COMPOSE_FILE_DEV) logs -f $1
+	@docker-compose -f $(COMPOSE_FILE_DEV) logs -f $(SERVICE)
 
 dev_compose_stop: get_opac_mongo_info get_opac_grpc_info
 	@docker-compose -f $(COMPOSE_FILE_DEV) stop

--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -7,6 +7,7 @@ from io import BytesIO, open as io_open
 
 from bs4 import BeautifulSoup
 from lxml import etree
+from packtools import HTMLGenerator
 
 from opac_proc.core import utils
 from opac_proc.logger_setup import getMongoLogger
@@ -35,7 +36,7 @@ class Assets(object):
 
     def __init__(self, xylose):
         self.xylose = xylose
-        self.content = None
+        self._content = None
 
     def _open_asset(self, file_path, mode='rb', encoding=None):
         """
@@ -71,7 +72,7 @@ class Assets(object):
                 if not isinstance(url, unicode):
                     url = url.encode('utf-8')
 
-                self.content = self.content.replace(media_name, url)
+                self._content = self._content.replace(media_name, url)
 
     def _extract_media(self):
         """
@@ -87,7 +88,7 @@ class Assets(object):
                 './/supplementary-material[@xlink:href]',
                 './/inline-supplementary-material[@xlink:href]',
             ]
-            xml_et = etree.XML(self.content.encode('utf-8'))
+            xml_et = etree.XML(self._content.encode('utf-8'))
             namespaces = {'xlink': 'http://www.w3.org/1999/xlink'}
             attrib_iters = [
                 xml_et.iterfind(attrib, namespaces=namespaces)
@@ -108,7 +109,7 @@ class Assets(object):
             ]
         else:
             parser = "html.parser"
-            soup = BeautifulSoup(self.content, parser)
+            soup = BeautifulSoup(self._content, parser)
             src_tags = [
                 tag.get('src').strip().encode('utf-8')
                 for tag in soup.find_all(src=True)
@@ -169,8 +170,9 @@ class Assets(object):
                 for lang in self.xylose.fulltexts().get('pdf').keys():
                     langs.add(lang)
 
-        logger.info(u"Artigo com PID: %s, tem os seguintes idiomas: %s",
-                    self.xylose.publisher_id, langs)
+        msg_info = u"Artigo com PID: %s, tem os seguintes idiomas: %s" % (
+            self.xylose.publisher_id, langs)
+        logger.info(msg_info)
 
         return list(langs)
 
@@ -211,27 +213,6 @@ class Assets(object):
 
         for _from, _to in change_media_path:
             media_path = media_path.replace(_from, _to.lower())
-
-        return (origin_path, media_path)
-
-    def _normalize_media_path_xml(self, media_path):
-        """
-        This method takes the path to the media and fits to known paths
-        and returns a tuple with the media path in the original html,
-        the path known in the file system.
-
-        In addition to making some extrension adjustments
-
-        Params:
-            :param media_path: the path to the media.
-                Example of paths:
-                    /img/revistas/rpmesp/v33n4/1726-4642-rpmesp-33-04-00819-gt1.tif
-        """
-
-        origin_path = media_path
-        change_media_path = [('tif', 'jpg')]
-        for _from, _to in change_media_path:
-            media_path = media_path.replace(_from, _to)
 
         return (origin_path, media_path)
 
@@ -278,8 +259,9 @@ class Assets(object):
 
         file_code = self.xylose.file_code()
 
-        logger.info(u"Idioma original do artigo PID: %s, original lang: %s",
-                    self.xylose.publisher_id, original_lang)
+        msg_info = u"Idioma original do artigo PID: %s, original lang: %s" % (
+            self.xylose.publisher_id, original_lang)
+        logger.info(msg_info)
 
         for lang in self._get_langs():
 
@@ -315,75 +297,6 @@ class Assets(object):
         metadata['issn'] = self.xylose.journal.any_issn()
 
         return metadata
-
-    def register_media_xml(self):
-        """
-        Return a dictionary with all media added in SSM.
-
-        Example:  {
-                    'a08tab01.gif': 'http://ssm.scielo.org/media/assets/resp/v89n1/a08tab01.gif'
-                    'a08tab3b.gif': 'http://ssm.scielo.org/media/assets/resp/v89n1/a08tab3b.gif'
-                  }
-        """
-        file_type = 'img'  # Not all are images
-        registered_medias = {}
-
-        medias = self._extract_media()
-
-        for media in medias:
-
-            origin_path, media_path = self._normalize_media_path_xml(media)
-
-            metadata = self.get_metadata()
-            metadata.update({'file_path': media_path,
-                             'bucket_name': self.bucket_name,
-                             'type': file_type,
-                             'origin_path': origin_path})
-
-            pfile = self._open_asset(self._get_media_path(media_path))
-
-            if not pfile:
-                continue
-
-            ssm_asset = SSMHandler(pfile, media_path, file_type, metadata,
-                                   self.bucket_name)
-
-            code, existing_asset = ssm_asset.exists()
-
-            # Existe mas não é idêntico (existe com o mesmo nome)
-            if code == 2:
-                logger.info(u"Já existe um media com PID: %s e colecao: %s, cadastrado: %s",
-                            self.xylose.publisher_id, self.xylose.collection_acronym, existing_asset)
-                logger.info(u"Lista de imagens com mesmo filename para o artigo com PID: %s, %s",
-                            self.xylose.publisher_id, existing_asset)
-                logger.info(u"Removendo a lista de images: %s", existing_asset)
-
-                for asset in existing_asset:
-                    ssm_asset.remove(asset['uuid'])
-
-            # Existe mas não é identico code=2, removido no passo anterior deve ser
-            # recadastrado, também deve ser cadastrado caso não exista, code=0.
-            if code == 2 or code == 0:
-                uuid = ssm_asset.register()
-
-                logger.info(u"UUID: %s para media do artigo com PID: %s",
-                            uuid, self.xylose.publisher_id)
-
-                registered_medias.update({origin_path: ssm_asset.get_urls()['url_path']})
-
-                logger.info(u"Medias(s): %s cadastrado(s) para o artigo com PID: %s",
-                            registered_medias, self.xylose.publisher_id)
-
-            # Existe e o ativo é idêntico
-            if code == 1:
-                for asset in existing_asset:
-                    metadata = json.loads(asset['metadata'])
-                    registered_medias.update({metadata['origin_path']:
-                                              asset['absolute_url']})
-
-                logger.info("Medias já existente no SSM: %s", registered_medias)
-
-        return registered_medias
 
     def register_media_html(self):
         """
@@ -568,6 +481,51 @@ class AssetPDF(Assets):
 
 class AssetXML(Assets):
 
+    def __init__(self, xylose):
+        super(AssetXML, self).__init__(xylose)
+        self._file_type = self.xylose.data_model_version
+        self._file_name = self._get_file_name(self._file_type)
+        self._content = self._get_content()
+
+    def _get_file_name(self, file_type, lang=None):
+        original_lang = self.xylose.original_language()
+        file_code = self.xylose.file_code()
+        prefix = ''
+        if lang and lang != original_lang:
+            prefix = '%s_' % lang
+
+        return u'{}{}.{}'.format(prefix, file_code, file_type)
+
+    def _get_content(self):
+        """
+        Get file content, calling a function to get the content according to it
+        type (PDF, XMl or HTML), path and file_name.
+        If there is no file_name, it raises an Exception according to config.
+        """
+        if not self._file_name:
+            msg_error = "Nao existe {} para o artigo, PID: {}".format(
+                self._file_type.upper(), self.xylose.publisher_id)
+            logger.error(msg_error)
+            if config.OPAC_PROC_RAISE_ERROR:
+                raise Exception(msg_error)
+            else:
+                return None
+
+        logger.info(u"{} existente para o artigo, PID: {}".format(
+            self._file_type.upper(), self._file_name))
+
+        parser = etree.XMLParser(remove_blank_text=True)
+        file_path = self._get_path(self._file_name)
+        try:
+            return etree.parse(file_path, parser)
+        except Exception as e:
+            msg_error = 'Erro no parser do XML: {}, erro: {}'.format(
+                file_path, e)
+            logger.error(msg_error)
+            if config.OPAC_PROC_RAISE_ERROR:
+                raise Exception(msg_error)
+            return None
+
     def _get_path(self, name):
         """
         Returns the folder path of article XML file.
@@ -578,6 +536,113 @@ class AssetXML(Assets):
                             self.xylose.assets_code,
                             name)
 
+    def _get_media(self):
+        """
+        Find all media elements in self._content (a etree._Element) and return a
+        generator with tuples (element, attrib_key), where element is a media
+        tree element and attrib_key is the xlink:href attrib.
+        Only media elements with href attrib that contains path with file
+        extension in MEDIA_EXTENSION_FILES are returned.
+        """
+        attribs = [
+            './/graphic[@xlink:href]',
+            './/media[@xlink:href]',
+            './/inline-graphic[@xlink:href]',
+            './/supplementary-material[@xlink:href]',
+            './/inline-supplementary-material[@xlink:href]',
+        ]
+        namespaces = {'xlink': 'http://www.w3.org/1999/xlink'}
+        attrib_iters = [
+            self._content.iterfind(attrib, namespaces=namespaces)
+            for attrib in attribs
+        ]
+        attrib_key = '{http://www.w3.org/1999/xlink}href'
+        ext_files_list = [
+            '.' + extension
+            for extension in config.MEDIA_EXTENSION_FILES.split(',')
+        ]
+        return (
+            (element, attrib_key)
+            for element in itertools.chain(*attrib_iters)
+            if os.path.splitext(element.attrib[attrib_key])[-1] in ext_files_list
+        )
+
+    def _register_ssm_media(self, pfile, media_path, file_type, metadata):
+        ssm_asset = SSMHandler(pfile, media_path, file_type, metadata,
+                               self.bucket_name)
+        code, existing_asset = ssm_asset.exists()
+        # Existe mas não é idêntico (existe com o mesmo nome)
+        if code == 2:
+            logger.info(u"Já existe um media com PID: {}".format(
+                        self.xylose.publisher_id))
+            for asset in existing_asset:
+                ssm_asset.remove(asset['uuid'])
+        # Existe mas não é identico code=2, removido no passo anterior deve ser
+        # recadastrado, também deve ser cadastrado caso não exista, code=0.
+        if code == 2 or code == 0:
+            uuid = ssm_asset.register()
+            logger.info(u"UUID: {} para media do artigo com PID: {}".format(
+                        uuid, self.xylose.publisher_id))
+            ssm_asset_url = ssm_asset.get_urls()['url_path']
+            logger.info(u"Media cadastrada para o artigo: {}".format(
+                ssm_asset_url))
+        # Existe e o ativo é idêntico
+        elif code == 1:
+            for asset in existing_asset:
+                ssm_asset_url = asset['absolute_url']
+            logger.info(u"Medias já existente no SSM: {}".format(ssm_asset_url))
+        return ssm_asset_url
+
+    def _normalize_media_path(self, media_path):
+        root, ext = os.path.splitext(media_path)
+        if ext == '.tif':
+            ext = '.jpg'
+        return root + ext
+
+    def _register_xml_medias(self):
+        file_type = 'img'  # Not all are images
+
+        for element, attrib in self._get_media():
+            original_path = element.attrib[attrib]
+            media_path = self._normalize_media_path(original_path)
+
+            metadata = self.get_metadata()
+            metadata.update({'file_path': media_path,
+                             'bucket_name': self.bucket_name,
+                             'type': file_type,
+                             'origin_path': original_path})
+
+            pfile = self._open_asset(self._get_media_path(media_path))
+            if pfile:
+                ssm_asset_url = self._register_ssm_media(
+                    pfile, media_path, file_type, metadata)
+                element.attrib[attrib] = ssm_asset_url
+
+    def _register_ssm_asset(self, pfile, file_name, file_type, metadata):
+        ssm_asset = SSMHandler(pfile, file_name, file_type, metadata,
+                               self.bucket_name)
+        code, assets = ssm_asset.exists()
+        if code == 2:
+            # Existe o Asset mas não é identico
+            logger.info(
+                "Já existe {} com PID {} cadastrado mas não é identico".format(
+                    file_type.upper(), self.xylose.publisher_id))
+            for asset in assets:
+                ssm_asset.remove(asset['uuid'])
+        if code == 0 or code == 2:
+            # Asset não cadastrado ou deletado no passo anterior
+            uuid = ssm_asset.register()
+            logger.info("UUID: {} para {} do artigo com PID: {}".format(
+                    uuid, file_type.upper(), self.xylose.publisher_id))
+            logger.info("{} cadastrado".format(file_name))
+            return (uuid, ssm_asset.get_urls()['url_path'])
+        elif code == 1:
+            # Existe o XML e é identico
+            logger.info("Já existe um {} com PID {} cadastrado".format(
+                    file_type.upper(), self.xylose.publisher_id))
+            if assets:
+                return (assets[0]['uuid'], assets[0]['full_absolute_url'])
+
     def register(self):
         """
         Method to register the XML(s) of the asset.
@@ -585,74 +650,68 @@ class AssetXML(Assets):
         To register the xml we must replace the path of the image to paths
         valid and registered in SSM.
         """
-        logger.info(u"Iniciando o cadasto do XML do artigo PID: %s",
-                    self.xylose.publisher_id)
+        logger.info(u"Iniciando o cadasto do XML do artigo PID: {}".format(
+                    self.xylose.publisher_id))
+        if self._content:
+            self._register_xml_medias()     # change self._content
 
-        logger.info(u"Registrando as medias para o PID: %s",
-                    self.xylose.publisher_id)
+            # passamos de content para bytes
+            content_as_bytes = BytesIO(
+                etree.tostring(self._content,
+                               xml_declaration=True,
+                               encoding='utf-8')
+            )
+            uuid, xml_url = self._register_ssm_asset(content_as_bytes,
+                                                     self._file_name,
+                                                     self._file_type,
+                                                     self.get_metadata())
+            return uuid, xml_url
 
-        if 'xml' not in self.get_assets():
-            msg_error = u"Nao existe XML para o artigo, PID: %s" % self.xylose.publisher_id
+    def register_htmls(self):
+        """
+        Register HTML contents from XML for all the text languages.
+        """
+        try:
+            generator = HTMLGenerator.parse(
+                self._content,
+                valid_only=False,
+                css=config.OPAC_PROC_ARTICLE_CSS_URL,
+                print_css=config.OPAC_PROC_ARTICLE_PRINT_CSS_URL,
+                js=config.OPAC_PROC_ARTICLE_JS_URL
+            )
+        except ValueError as e:
+            logger.error('Error getting htmlgenerator: {}.'.format(e.message))
+            return None
 
-            logger.error(msg_error)
+        registered_htmls = []
+        for lang, trans_result in generator:
+            html_as_bytes = None
+            try:
+                html = etree.tostring(trans_result, pretty_print=True,
+                                      encoding='utf-8', method='html',
+                                      doctype="<!DOCTYPE html>")
+                html_as_bytes = BytesIO(html)
+            except Exception as e:
+                logger.error(
+                    'Error converting etree {} to string. '.format(lang))
+            else:
+                metadata = self.get_metadata()
+                metadata.update({'bucket_name': self.bucket_name,
+                                 'type': 'html',
+                                 'version': 'xml'})
+                __, html_url = self._register_ssm_asset(
+                    html_as_bytes,
+                    self._get_file_name('html', lang),
+                    'html',
+                    metadata
+                )
+                registered_htmls.append({
+                    'type': 'html',
+                    'lang': lang,
+                    'url': html_url
+                })
 
-            if config.OPAC_PROC_RAISE_ERROR:
-                raise Exception(msg_error)
-
-        else:
-            logger.info(u"XML existente para o artigo, PID: %s",
-                        self.get_assets().get('xml'))
-
-            file_name = self.get_assets().get('xml')
-            file_path = self._get_path(self.get_assets().get('xml'))
-
-            self.content = self._open_asset(file_path, mode='r', encoding='utf-8').read()
-
-            registered_media = self.register_media_xml()
-
-            logger.info(u"Medias cadastradas para o XML com PID: %s, %s",
-                        self.xylose.publisher_id, registered_media)
-
-            logger.info(u"Alterando as medias:%s no artigo PID: %s",
-                        registered_media, self.xylose.publisher_id)
-
-            logger.info(u"Medias registradas %s", registered_media)
-
-            self._change_img_path(registered_media)  # change self.content
-
-            # passamos de content em unicode depois do replace. para bytes
-            content_as_bytes = BytesIO(self.content.encode('utf-8'))
-            ssm_asset = SSMHandler(content_as_bytes, file_name,
-                                   'xml', self.get_metadata(), self.bucket_name)
-
-            code, assets = ssm_asset.exists()
-
-            # Existe o XML e é identico
-            if code == 1:
-                logger.info(u"Já existe um XML com PID: %s e coleção: %s, cadastrado",
-                            self.xylose.publisher_id, self.xylose.collection_acronym)
-                if assets:
-                    return (assets[0]['uuid'], assets[0]['full_absolute_url'])
-
-            if code == 2:
-                logger.info(u"Já existe um XML com PID: %s e coleção: %s, cadastrado,\
-                            porém não é identico", self.xylose.publisher_id,
-                            self.xylose.collection_acronym)
-
-                for asset in assets:
-                    ssm_asset.remove(asset['uuid'])
-
-            if code == 0 or code == 2:
-
-                uuid = ssm_asset.register()
-
-                logger.info(u"UUID: %s para XML do artigo com PID: %s",
-                            uuid, self.xylose.publisher_id)
-
-                logger.info(u"XML: %s cadastrado para o artigo com PID: %s",
-                            file_name, self.xylose.publisher_id)
-
-                return (uuid, ssm_asset.get_urls()['url_path'])
+        return registered_htmls
 
 
 class AssetHTMLS(Assets):
@@ -714,13 +773,13 @@ class AssetHTMLS(Assets):
                 # É necessário fazer o mesmo procedimento que é relizado no XML
                 # Cadastrar as medias e alterar o caminho diretamente no HTML
 
-                self.content = html
+                self._content = html
                 registered_media = self.register_media_html()
 
                 logger.info(u"O artigo com PID: %s é uma versão HTML.",
                             self.xylose.publisher_id)
 
-                self._change_img_path(registered_media)  # change self.content
+                self._change_img_path(registered_media)  # change self._content
 
                 # Substitui a seta.jpg'
                 patterns = config.OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS.split(',')
@@ -731,14 +790,14 @@ class AssetHTMLS(Assets):
 
                     pattern = re.compile(pattern_string)
 
-                    if re.search(pattern, self.content):
-                        self.content = re.sub(pattern, arrow, self.content)
+                    if re.search(pattern, self._content):
+                        self._content = re.sub(pattern, arrow, self._content)
 
                 directory = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                          'templates')
 
                 html = utils.render_from_template(directory, 'article.html', {
-                                                  'html': self.content,
+                                                  'html': self._content,
                                                   'css': config.OPAC_PROC_ARTICLE_CSS_URL,
                                                   'css_print': config.OPAC_PROC_ARTICLE_PRINT_CSS_URL
                                                   })

--- a/opac_proc/tests/fixtures/1851-8265-scol-14-01-51.xml
+++ b/opac_proc/tests/fixtures/1851-8265-scol-14-01-51.xml
@@ -1,0 +1,1623 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article
+  PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.8" xml:lang="es" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="nlm-ta">Salud Colect</journal-id>
+			<journal-id journal-id-type="publisher-id">scol</journal-id>
+			<journal-title-group>
+				<journal-title>Salud Colectiva</journal-title>
+				<abbrev-journal-title abbrev-type="publisher">Salud Colect</abbrev-journal-title>
+			</journal-title-group>
+			<issn pub-type="ppub">1669-2381</issn>
+			<issn pub-type="epub">1851-8265</issn>
+			<publisher>
+				<publisher-name>Universidad Nacional de Lanús</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="doi">10.18294/sc.2018.1200</article-id>
+			<article-categories>
+				<subj-group subj-group-type="heading">
+					<subject>ARTÍCULOS</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>Cáncer infantil: incidencia y patrones espaciales en la ciudad de Campinas, Brasil, 1996-2005</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-5432-9560</contrib-id>
+					<name>
+						<surname>Oliveira Friestino</surname>
+						<given-names>Jane Kelly</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0003-4835-8944</contrib-id>
+					<name>
+						<surname>Mendonça</surname>
+						<given-names>Denisa</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff2"><sup>2</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-2470-0795</contrib-id>
+					<name>
+						<surname>Oliveira</surname>
+						<given-names>Pedro</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff3"><sup>3</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-4594-1723</contrib-id>
+					<name>
+						<surname>Oliveira</surname>
+						<given-names>Carla M</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff4"><sup>4</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-7943-0868</contrib-id>
+					<name>
+						<surname>de Carvalho Moreira</surname>
+						<given-names>Djalma</given-names>
+						<suffix>Filho</suffix>
+					</name>
+					<xref ref-type="aff" rid="aff5"><sup>5</sup></xref>
+				</contrib>
+			</contrib-group>
+			<aff id="aff1">
+				<label>1</label>
+				<institution content-type="original">Doctora en Salud Colectiva. Profesora, Universidade Federal da Fronteira Sul, Chapecó, Brasil. jane.friestino@uffs.edu.br</institution>
+				<institution content-type="normalized">Universidade Federal da Fronteira Sul</institution>
+				<institution content-type="orgname">Universidade Federal da Fronteira Sul</institution>
+				<addr-line>
+					<city>Chapecó</city>
+				</addr-line>
+				<country country="BR">Brazil</country>
+				<email>jane.friestino@uffs.edu.br</email>
+			</aff>
+			<aff id="aff2">
+				<label>2</label>
+				<institution content-type="original">Doctora en Bioestadística. Profesora, Epidemiology Research Unit, Instituto de Saúde Pública, Instituto de Ciências Biomédicas Abel Salazar, Universidade do Porto, Portugal. dvmendon@icbas.up.pt</institution>
+				<institution content-type="normalized">Universidade do Porto</institution>
+				<institution content-type="orgdiv1">Instituto de Ciências Biomédicas Abel Salazar</institution>
+				<institution content-type="orgname">Universidade do Porto</institution>
+				<country country="PT">Portugal</country>
+				<email>dvmendon@icbas.up.pt</email>
+			</aff>
+			<aff id="aff3">
+				<label>3</label>
+				<institution content-type="original">Doctor en Bioestadística. Profesor, Epidemiology Research Unit, Instituto de Saúde Pública, Instituto de Ciências Biomédicas Abel Salazar, Universidade do Porto, Portugal. pnoliveira@icbas.up.pt</institution>
+				<institution content-type="normalized">Universidade do Porto</institution>
+				<institution content-type="orgdiv1">Instituto de Ciências Biomédicas Abel Salazar</institution>
+				<institution content-type="orgname">Universidade do Porto</institution>
+				<country country="PT">Portugal</country>
+				<email>pnoliveira@icbas.up.pt</email>
+			</aff>
+			<aff id="aff4">
+				<label>4</label>
+				<institution content-type="original">Doctora en Salud Pública. Profesora Asistente Invitada, Escola Superior de Saúde, Instituto Politécnico do Porto. Investigadora, Instituto de Investigação e Inovação em Saúde (i3s), Instituto de Engenharia Biomédica, Universidade do Porto, Portugal. carlaoliver@gmail.com</institution>
+				<institution content-type="normalized">Universidade do Porto</institution>
+				<institution content-type="orgdiv1">Instituto de Investigação e Inovação em Saúde (i3s)</institution>
+				<institution content-type="orgdiv2">Instituto de Engenharia Biomédica</institution>
+				<institution content-type="orgname">Universidade do Porto</institution>
+				<country country="PT">Portugal</country>
+				<email>carlaoliver@gmail.com</email>
+			</aff>
+			<aff id="aff5">
+				<label>5</label>
+				<institution content-type="original">Doctor en Medicina Preventiva. Profesor, Universidade Estadual de Campinas, Brasil. djalmore@unicamp.br</institution>
+				<institution content-type="normalized">Universidade Estadual de Campinas</institution>
+				<institution content-type="orgname">Universidade Estadual de Campinas</institution>
+				<country country="BR">Brazil</country>
+				<email>djalmore@unicamp.br</email>
+			</aff>
+			<pub-date pub-type="epub-ppub">
+				<season>Jan-Mar</season>
+				<year>2018</year>
+			</pub-date>
+			<volume>14</volume>
+			<issue>1</issue>
+			<fpage>51</fpage>
+			<lpage>63</lpage>
+			<history>
+				<date date-type="received">
+					<day>31</day>
+					<month>10</month>
+					<year>2016</year>
+				</date>
+				<date date-type="rev-recd">
+					<day>26</day>
+					<month>05</month>
+					<year>2017</year>
+				</date>
+				<date date-type="accepted">
+					<day>28</day>
+					<month>08</month>
+					<year>2017</year>
+				</date>
+			</history>
+			<permissions>
+				<license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by-nc/4.0/" xml:lang="es">
+					<license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons</license-p>
+				</license>
+			</permissions>
+			<abstract>
+				<title>RESUMEN </title>
+				<p>Analizamos los patrones espaciales y las incidencias de cáncer en niños, niñas y adolescentes de 0 a 19 años de edad residentes en la ciudad de Campinas, al sureste de Brasil, diagnosticados entre 1996 y 2005. Se clasificaron los cánceres según los grupos de la tercera revisión de la <italic>International Classification of Childhood Cancer</italic> (ICCC-3). Se incluyeron los cuatro grupos más comunes: leucemias, linfomas, y las neoplasias del sistema nervioso central y de tejidos blandos. Se calcularon tasas de incidencia estandarizadas por edad utilizando la población mundial estándar. Se ajustó un modelo espacial de regresión jerárquica de Bayes (controlando por la heterogeneidad de los datos y la autocorrelación espacial), que asume que el número de casos sigue una distribución de Poisson. Se diagnosticó un total de 180 casos durante el periodo de estudio. La tasa de incidencia bruta para las edades 0-19 años fue de 54,2 por millón y la tasa de incidencia estandarizada por edad fue de 56,5 por millón. Si bien algunas regiones presentan tasas de incidencia más altas al considerar la heterogeneidad y la autocorrelación, no se observaron diferencias estadísticamente significativas en los riesgos relativos. </p>
+			</abstract>
+			<kwd-group xml:lang="es">
+				<title>PALABRAS CLAVES: </title>
+				<kwd>Análisis Espacial</kwd>
+				<kwd>Neoplasias</kwd>
+				<kwd>Salud Infantil</kwd>
+				<kwd>Salud del Adolescente</kwd>
+				<kwd>Geografía Médica</kwd>
+				<kwd>Brasil</kwd>
+			</kwd-group>
+			<counts>
+				<fig-count count="6"/>
+				<table-count count="2"/>
+				<equation-count count="20"/>
+				<ref-count count="33"/>
+				<page-count count="13"/>
+			</counts>
+		</article-meta>
+	</front>
+	<body>
+		<sec sec-type="intro">
+			<title>INTRODUCCIÓN</title>
+			<p>El Sistema Único de Salud (SUS), como parte integral del sistema de protección social brasileño, tiene entre sus objetivos la identificación de factores y determinantes de salud y el uso de indicadores para describir las situaciones de salud y bienestar de la población<xref ref-type="bibr" rid="B1"><sup>1</sup></xref>.</p>
+			<p>En este escenario, la salud colectiva en Brasil ha pasado por reestructuraciones desde la reforma de salud de mediados de la década de 1970. Con base en concepciones de la medicina social, la salud colectiva se constituye actualmente como un campo científico que contribuye al estudio el proceso de salud-enfermedad-atención-cuidado en diversos grupos poblaciones insertos en contextos geográficos, históricos y sociales específicos<xref ref-type="bibr" rid="B2"><sup>2</sup></xref>.</p>
+			<p>La epidemiología actual, especialmente la epidemiología social, ha superado los modelos explicativos del proceso salud-enfermedad de la década de 1970. Hoy en día la epidemiología incluye en sus métodos de investigación la experticia de otras áreas de conocimiento y, por lo tanto, no deja de tener en cuenta elementos importantes como la complejidad existente en los diversos ciclos de la vida humana, reuniendo tanto el espacio y el tiempo en los que se inscriben los individuos<xref ref-type="bibr" rid="B3"><sup>3</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B4"><sup>4</sup></xref>.</p>
+			<p>Desde la perspectiva de la epidemiología social, la salud se considera un componente relevante del bienestar, no solo del individuo, sino de la sociedad, además de una condición esencial para el disfrute de la vida y un derecho inalienable de las personas sin importar el lugar en donde viven. Los cambios en la estructura general de la sociedad, los cambios climáticos, el envejecimiento poblacional, el crecimiento de la desigualdad y el acceso a los cuidados en salud son algunas de las problemáticas que han despertado el reconocimiento de la importancia del territorio y de la geografía en el análisis de las condiciones de salud, haciendo que esta área de conocimiento cobre relevancia en el campo de la salud colectiva.</p>
+			<p>Según Barcellos<xref ref-type="bibr" rid="B5"><sup>5</sup></xref>, la geografía de la salud:</p>
+			<disp-quote>
+				<p>…es un campo de conocimiento que debería involucrar los varios técnicos y profesionales que se interesan por los procesos de salud, enfermedad y cuidado en el espacio geográfico, para poder intervenir.</p>
+			</disp-quote>
+			<p>Actualmente, en la bibliografía es posible encontrar un gran número de estudios que analizan enfermedades crónicas y no transmisibles, en particular, la ocurrencia de neoplasias<xref ref-type="bibr" rid="B4"><sup>4</sup></xref>. Como se consideran enfermedades multifactoriales, varios factores influyen en la distribución geográfica de las neoplasias, especialmente, los determinantes sociales, el ambiente y el acceso a los servicios de salud. Una herramienta esencial para la vigilancia epidemiológica de la incidencia de cáncer son los Registros de Cáncer de Base Poblacional. Estos registros son fuentes fundamentales para el desarrollo de la investigación epidemiológica y clínicas y, además, para la planificación y la evaluación de las acciones de control de cáncer.</p>
+			<p>Dada la importancia de conocer la incidencia del cáncer en la población, desde la década de 1980, el Instituto Nacional del Cáncer de Brasil ha promovido el establecimiento de registros, motivo por el cual en la actualidad hay 20 Registros de Cáncer de Base Poblacional distribuidos por las grandes ciudades de todas las regiones de país<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>. La mayor parte de las investigaciones se orientan hacia los tipos de neoplasias con mayor incidencia, quizá debido a la facilidad para obtener los datos o a la gran cantidad de información necesaria para la elaboración de los planes de contingencia; por lo tanto, los estudios sobre casos poco frecuentes escasean en la bibliografía<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>.</p>
+			<p>Campinas es una ciudad grande ubicada en el suroeste de Brasil. Cuenta con un Registro de Cáncer de Base Poblacional desde 1990. Aunque los estudios poblacionales sobre la incidencia del cáncer infantil y la supervivencia son importantes para evaluar los servicios locales de salud, pocos estudios se encuentran disponibles para la región.</p>
+			<p>El cáncer infantil (diagnosticado entre las edades de 0 y 19 años) incluye varias malignidades y la incidencia varía mundialmente según edad, género, etnicidad y geografía. Dicha variación podría iluminar aspectos de la etiología del cáncer<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B9"><sup>9</sup></xref>. Este tipo de cáncer se considera raro cuando se compara con el cáncer en adultos, dado que representa aproximadamente del 2,5% al 3% de todos los tipos de cáncer en América Latina y el Caribe<xref ref-type="bibr" rid="B6"><sup>6</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B10"><sup>10</sup></xref>.</p>
+			<p>A pesar de la baja incidencia, el número de casos nuevos en este grupo de edad representa un gran impacto para la salud pública debido a que las tasas de mortalidad frecuentemente son altas, y las consecuencias severas producto del tratamiento y de las neoplasias en sí se ven agravados por el sufrimiento experimentado por la familia<xref ref-type="bibr" rid="B11"><sup>11</sup></xref>. </p>
+			<p>En Brasil, el 32,9% de la población tiene menos de 19 años de edad<xref ref-type="bibr" rid="B12"><sup>12</sup></xref> y aunque el cáncer en este grupo de edad es poco frecuente, se estima que hubo 11.530 casos en niños en 2012 en Brasil. Según un estudio publicado en 2009, que utilizó datos de 14 Registros de Cáncer de Base Poblacional de Brasil, la incidencia promedio era de 154,3 por millón de niños<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>. </p>
+			<p>El cáncer tiene comportamientos específicos en este grupo de edad, por lo tanto, la implementación de monitoreo es una medida que sirve tanto para la prevención como para la producción de conocimiento, lo que concede mayor visibilidad al problema.</p>
+			<p> Es sabido que en Brasil existen desigualdades en el acceso a los servicios de salud para el tratamiento del cáncer infantil. En este sentido, Brasil tiene características similares a las de otros países en desarrollo, en los que se conoce poco sobre la magnitud del cáncer. Esta situación impide la planificación de acciones de salud y la implementación de estrategias para la prevención y el cuidado en la población en su totalidad<xref ref-type="bibr" rid="B13"><sup>13</sup></xref>.</p>
+			<p>Dadas las características especiales del cáncer infantil, los estudios epidemiológicos son de suma importancia. Analizan la distribución de casos en la comunidad y construyen indicadores y ponderaciones para generar mayor conocimiento sobre los eventos, lo cual es esencial para conocer la población afectada y las exigencias sobre el sistema de salud<xref ref-type="bibr" rid="B14"><sup>14</sup></xref>.</p>
+			<p>En Scott<xref ref-type="bibr" rid="B15"><sup>15</sup></xref> se evaluó positivamente el uso de sistemas de información geográfica (SIG) en la creación de un sistema de información en salud sobre cáncer. Aunque los datos registrados en Sudáfrica estaban incompletos, la técnica mostró la potencialidad de agregar valor al sistema de información, y de aportar datos respecto de la demanda que hasta el momento no se habían tenido en cuenta.</p>
+			<p>En muchos países de bajos y medianos ingresos, aunque existan registros de cáncer de base poblacional, se desconoce la información sobre cáncer infantil dado que no se recopila información sobre la incidencia del cáncer, por lo que puede ser necesario acudir a otras fuentes de datos y someter las estadísticas resultantes a un control de calidad meticuloso. Respecto de la incidencia del cáncer infantil a nivel mundial, solo hay tres publicaciones disponibles: una de 1988, otra de 1998 y una más reciente de 2017. Las distancias entre estas fechas resaltan la complejidad que existe en los registros de cáncer infantil, dado que son más sensibles a imprecisiones o información faltante<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>.</p>
+			<p>Un mejor conocimiento de la incidencia y de los patrones espaciales del cáncer infantil en el área local puede ayudar a direccionar los servicios de salud y ofrecer claves para la planificación en el sistema de salud<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B16"><sup>16</sup></xref>. Aunque el análisis geográfico puede ser innovador con respecto a la información sobre incidencia del cáncer, se sabe que existe una laguna en la bibliografía científica respecto de este tema. Por lo tanto, este estudio analiza los patrones espaciales de la incidencia del cáncer en niños y niñas de 0-14 años y adolescentes de 15-19 años, residentes de Campinas que fueron diagnosticados en el periodo 1996-2005. El estudio forma parte de una tesis doctoral defendida en 2015 bajo el título “<italic>Panorama do câncer em crianças e adolescentes sob a perspectiva da saúde coletiva</italic>”<xref ref-type="bibr" rid="B17"><sup>17</sup></xref>.</p>
+		</sec>
+		<sec sec-type="materials|methods">
+			<title>MATERIAL Y MÉTODOS</title>
+			<p>Se realizó un estudio observacional retrospectivo sobre el cáncer en niños, niñas y adolescentes de 0 a 19 años de edad, en Campinas, San Pablo, Brasil, diagnosticados en el periodo 1996-2005.</p>
+			<p>Campinas es una ciudad industrial ubicada en el estado de San Pablo, Brasil, con aproximadamente 1,1 millones de habitantes. Alrededor del 30% de la población que vive en Campinas tiene menos de 19 años de edad. Durante el periodo de estudio hubo un incremento del 8,34% en la población menor a 19 años<xref ref-type="bibr" rid="B12"><sup>12</sup></xref>.</p>
+			<p>En 2000, el Departamento Municipal de Salud de Campinas dividió la ciudad en 47 áreas de cubertura de las unidades de salud, las cuales conforman las unidades geográficas utilizadas en el análisis espacial. La población menor de 19 años en estas áreas fue de entre 1.099 y 7.036, con una mediana de 3.429.</p>
+			<p>La mayor atención para el cáncer infantil ocurre en la Unidad de Alta Complejidad de Oncología Pediátrica, y según un análisis del Registro de Cáncer con Base Poblacional de Campinas, la unidad tiene una cobertura del 85% de todos los casos incidentes en la ciudad para este grupo de edad<xref ref-type="bibr" rid="B18"><sup>18</sup></xref>.</p>
+			<p>Aunque Campinas cuenta con un Registro de Cáncer con Base Poblacional, no disponía de datos para el periodo de tiempo contemplado en esta investigación. Por lo tanto, el estudio se realizó en la mencionada Unidad de Alta Complejidad de Oncología Pediátrica, utilizando todos los pasos de recolección de datos ya validados en los Registros de Cáncer con Base Poblacional y la notificación activa de casos como el principal procedimiento para la recopilación de datos.</p>
+			<p>El presente estudio se realizó de acuerdo con la Resolución 196/96 del Consejo Nacional de Salud de Brasil. La investigación mayor en la que se basa este artículo fue aprobada por el Comité de Ética en Investigación Humana del Centro Infantil Boldrini (CEP-Boldrini) (CAAE 0566.0.000.144-11) Nº 06/2011, el 13 de mayo de 2011.</p>
+			<sec>
+				<title>Definición de caso</title>
+				<p>Se recopilaron datos de niños, niñas y adolescentes residentes en Campinas, de 0 a 19 años de edad que habían sido diagnosticados entre el 1 de enero de 1996 y el 31 de diciembre de 2005. Se obtuvieron los diagnósticos confirmados de cáncer a través de las historias clínicas, y se utilizó la fecha de diagnóstico del primer tumor primario. Para evitar la inclusión de casos no provenientes de la población en riesgo, se llevó a cabo un chequeo manual de los datos y se comparó la dirección del domicilio de los casos con el área geográfica incluida en el estudio.</p>
+				<p>Los cánceres se clasificaron según la <italic>International Classification of Childhood Cancer</italic>, tercera revisión (ICCC-3)<xref ref-type="bibr" rid="B19"><sup>19</sup></xref>. Se excluyeron los tumores benignos y solo se incluyeron los cuatro grupos más comunes: Grupo I, Leucemias; Grupo II, Linfomas y neoplasias reticuloendoteliales; Grupo III, Sistema nervioso central y miscelánea de neoplasias intracraneales e intraespinales, y Grupo IX, Sarcomas de tejidos blandos y otros extraóseos.</p>
+			</sec>
+			<sec>
+				<title>Incidencia de cáncer</title>
+				<p>Las persona-año del periodo incluido en el estudio se obtuvieron a través de estimaciones de población del Instituto Brasilero de Geografía y Estadística (IBGE)<xref ref-type="bibr" rid="B12"><sup>12</sup></xref>. Las tasas de incidencia promedio anuales brutas y estandarizadas, calculadas por 1.000.000 de habitantes, expresan el riesgo de nuevos casos. Los denominadores poblacionales utilizados para el cálculo de las tasas de incidencia se basaron en el censo demográfico de 2000 y proyecciones estimadas para los años restantes<xref ref-type="bibr" rid="B12"><sup>12</sup></xref>. Se calcularon tasas de incidencia específicas por edad, por millón de habitantes, para niños, niñas y adolescentes residentes en la ciudad de Campinas<xref ref-type="bibr" rid="B12"><sup>12</sup></xref>. Las tasas de incidencia estandarizadas por edad se calcularon por método directo y se utilizó la población mundial estándar<xref ref-type="bibr" rid="B20"><sup>20</sup></xref> para controlar las diferencias que pudieran existir en la estructura de edad y sexo entre regiones y poder comparar las tasas de incidencia entre regiones. En otras palabras, considerando que <italic>yijk</italic> representa el número de casos de cáncer (entre 1996 y 2005) en las áreas de cobertura <italic>i</italic> (<italic>i=</italic>1,...,47), en el sexo <italic>j</italic> (<italic>j</italic>=1,2) y grupo de edad <italic>k</italic> (<italic>k=</italic>1,...,4 respectivamente para los grupos de edad 0-4, 5-9, 10-14 and 15-19 años) y <italic>Nijk</italic> el número de individuos en riesgo en área <italic>i</italic>, sexo <italic>j</italic>, grupo de edad <italic>k</italic>, las tasas de incidencia estandarizadas por edad (TIEE) se estimaron mediante:</p>
+				<p>
+					<disp-formula id="e1">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e1.jpg"/>
+					</disp-formula>
+				</p>
+				<p>Donde</p>
+				<p>
+					<disp-formula id="e2">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e2.jpg"/>
+					</disp-formula>
+				</p>
+				<p>representa el número de casos esperados para cada región <italic>i</italic>, donde <italic>NPjk</italic> representa el número de individuos en la población mundial de sexo <italic>j</italic> y grupo de edad <italic>k</italic>, y <italic>CIRijk=yijk/ Nijk</italic> representa la tasa cruda de incidencia de región <italic>i</italic>, en sexo <italic>j</italic> y grupo de edad <italic>k</italic>. El intervalo de confianza se calculó con el método exacto con base en la distribución de Poisson (apropiada para números pequeños). </p>
+			</sec>
+			<sec>
+				<title>Análisis espacial</title>
+				<p>Los mapas digitales de los límites administrativos fueron realizados por el IBGE. Utilizamos las áreas de las unidades sanitarias que corresponden al área de cobertura de los centros de salud de la ciudad y su respectiva población.</p>
+				<p> La medida convencional utilizada en el mapeo de las enfermedades es la razón de morbilidad estandarizada (RME), que refiere a la incidencia en este periodo. Para cada área <italic>i,</italic> la RME se define como la razón entre casos observados <italic>yi</italic> y casos esperados <italic>ei</italic>. </p>
+				<p>Los <italic>ei</italic> fueron calculados con base en la estandarización indirecta, para controlar el efecto de sexo y edad<xref ref-type="bibr" rid="B21"><sup>21</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B22"><sup>22</sup></xref>.</p>
+				<p>Los casos esperados se calcularon de la siguiente manera: considerando <italic>i</italic> el índice del área de cobertura de la unidad sanitaria, <italic>j</italic> el índice de sexo y <italic>k</italic> el índice del grupo de edad, entonces <italic>yijk</italic> representa el número de eventos de sexo <italic>j</italic> y grupo de edad <italic>k</italic> en el área <italic>i</italic>, y <italic>Nijk</italic> el número de personas en riesgo por sexo <italic>j,</italic> grupo de edad <italic>k</italic>, en el área <italic>i</italic>. </p>
+				<p>La tasa global para la ciudad por grupo de edad y sexo se dio por la siguiente expresión:</p>
+				<p>
+					<disp-formula id="e3">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e3.jpg"/>
+					</disp-formula>
+				</p>
+				<p>Luego la expresión:</p>
+				<p>
+					<disp-formula id="e4">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e4.jpg"/>
+					</disp-formula>
+				</p>
+				<p>representa el número de eventos esperados en el área <italic>i</italic>, sexo <italic>j</italic> y grupo de edad <italic>k</italic>. De esta manera el número de eventos esperados en el área <italic>i</italic>, asumiendo un riesgo constante en cada clase de edad y sexo, se expresa a través de: </p>
+				<p>
+					<disp-formula id="e5">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e5.jpg"/>
+					</disp-formula>
+				</p>
+				<p>es decir, la suma de valores esperados en el área sobre las clases de edad y sexo. La RME ajustada por grupo de edad y sexo para cada área de unidad sanitaria <italic>i</italic> (<italic>i</italic>=1,...,47), asumiendo que el riesgo es constante en cada área, se expresa a través de:</p>
+				<p>
+					<disp-formula id="e6">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e6.jpg"/>
+					</disp-formula>
+				</p>
+				<p>Para controlar por la heterogeneidad de los datos y la autocorrelación espacial entre áreas, se ajustó un modelo espacial de regresión jerárquico bayesiano. Los parámetros de interés se estimaron a través del siguiente modelo:</p>
+				<p>
+					<disp-formula id="e7">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e7.jpg"/>
+					</disp-formula>
+				</p>
+				<p>donde </p>
+				<p>
+					<disp-formula id="e8">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e8.jpg"/>
+					</disp-formula>
+				</p>
+				<p>
+					<disp-formula id="e9">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e9.jpg"/>
+					</disp-formula>
+				</p>
+				<p>La inclusión de los efectos aleatorios <italic>Øi</italic> introduce un efecto latente en el modelo para capturar el impacto de factores confusores desconocidos o no observados a nivel del área. Estos efectos aleatorios no estructurados espacialmente pueden explicar la sobredispersión (presencia de mayor variabilidad en los datos) en la distribución del conteo de la incidencia de cáncer infantil <italic>yi</italic>. Sin embargo, no permite dependencia espacial explícita entre <italic>yi</italic>. Esta dependencia se incluyó al agregar el efecto aleatorio estructurado espacialmente <italic>vi</italic>. Para permitir la dependencia espacial, se asume un modelo condicionalmente autoregresivo (CAR)<xref ref-type="bibr" rid="B21"><sup>21</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B22"><sup>22</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B23"><sup>23</sup></xref><sup>)</sup> para <italic>vi</italic>, definido por: </p>
+				<p>
+					<disp-formula id="e10">
+						<graphic xlink:href="1851-8265-scol-14-01-51-e10.jpg"/>
+					</disp-formula>
+				</p>
+				<p>donde <italic>wij</italic> son los pesos de adyacencia para las áreas. En el estudio los valores de <italic>wij</italic> se tomaron como binarios simples: <italic>wij</italic>=1 si el área <italic>i</italic> tiene un límite común con el área <italic>j</italic> y <italic>wij</italic>=0 de lo contario; <italic>σv</italic> sirvió como hiperparámetro que controla la fuerza de la dependencia local espacial.</p>
+				<p>Se asumieron distribuciones <italic>a priori</italic> no informativas para los parámetros del modelo. Se le dio al parámetro α una distribución <italic>a priori</italic> gaussiana con un promedio de 0 y una gran varianza (1.000), mientras para la inversa de <inline-graphic xlink:href="1851-8265-scol-14-01-51-i011.jpg"/> y <inline-graphic xlink:href="1851-8265-scol-14-01-51-i012.jpg"/> se asumió una distribución <italic>a priori</italic> Gamma (0,5; 0,0005)<xref ref-type="bibr" rid="B24"><sup>24</sup></xref>.</p>
+				<p>Se estimaron el riesgo relativo (RR) y los intervalos de credibilidad del 95%, utilizando el promedio y los cuantiles empíricos del 2,5% y 97,5% respectivamente, de las muestras <italic>a posteriori</italic> de cada parámetro de interés. Estas muestras se basan en dos cadenas de Markov con método Monte Carlo [<italic>Markov chain Monte Carlo</italic>] (MCMC) con 100.000 iteraciones cada una y un periodo de calentamiento (<italic>burn-in</italic>) de 10.000. Todos los puntos de corte utilizados en los mapas corresponden a los cuartiles de las mediciones que presentamos.</p>
+				<p>Los análisis se realizaron con los siguientes softwares: SPSS, Geoda, Winbugs (WinBUGS14, Cambridge, UK)<xref ref-type="bibr" rid="B25"><sup>25</sup></xref> y R versión 2.14.1 (Project for Statistical Computing)<xref ref-type="bibr" rid="B26"><sup>26</sup></xref>, utilizando el paquete R2WinBUGS para conectar las últimas dos herramientas. WinBUGS utiliza el muestreo de Gibbs, un método específico de MCMC, para producir muestras de la posterior distribución de cada parámetro.</p>
+			</sec>
+		</sec>
+		<sec sec-type="results">
+			<title>RESULTADOS</title>
+			<p>Se diagnosticaron 180 casos en total, 154 niños y niñas y 26 adolescentes. La <xref ref-type="table" rid="t1">Tabla 1</xref> representa la frecuencia de distribución absoluta de casos de tumores por grupo diagnóstico además de las tasas de incidencia por millón según edad -estratificadas en dos grupos, 0-14 y 15-19 años- y grupo diagnóstico. Las neoplasias más frecuentes fueron: leucemia linfoblástica aguda (niños y niñas: 37,7%; adolescentes: 15,4%), leucemia aguda no linfoblástica (niños y niñas: 13%; adolescentes: 23,1%), astrocitomas (niños y niñas: 11%) y linfoma de Hodgkin (adolescentes: 19,2%) (<xref ref-type="table" rid="t1">Tabla 1</xref>).</p>
+			<p>
+				<table-wrap id="t1">
+					<label>Tabla 1</label>
+					<caption>
+						<title>Frecuencia, razón hombre-mujer y tasas de incidencia (por millón) según grupo diagnóstico de cáncer y grupo de edad en niños, niñas y adolescentes de 0 a 19 años. Campinas, San Pablo, Brasil, 1996-2005.</title>
+					</caption>
+					<graphic xlink:href="1851-8265-scol-14-01-51-gt1.jpg"/>
+					<table-wrap-foot>
+						<fn id="TFN1">
+							<p>Fuente: Elaboración propia con datos. TIEE = Tasas de incidencia estandarizadas por edad.</p>
+						</fn>
+					</table-wrap-foot>
+				</table-wrap>
+			</p>
+			<p>Entre niñas y niños, los tumores más frecuentes se encontraron en el Grupo I, que representó el 52% de todas las neoplasias incidentes, seguido por el Grupo III (22,7%) y Grupo II (18,1%). Entre adolescentes, el Grupo II representó el 42,2% de los diagnósticos, seguido por el Grupo I (38,5%) y el Grupo III (11,5%). Se observan diferencias pronunciadas en la razón hombre/mujer para el Grupo II.</p>
+			<p>La tasa de incidencia bruta para las edades en estudio fue de 54,2 casos por millón [IC95% (46,2-62,1)]; para niñas y niños fue del 64,2 [IC95% (54,0-74,3)] y para adolescentes 28,2 [IC95% (17,3-39,0)]. La tasa estandarizada por edad para todas estas edades fue del 56,5 [IC95% (48,1-64,9)]. Para el Grupo I, fue del 28,8 [IC95% (22,7-34,8)]; Grupo II, 11,6 [IC95% (7,85-15,2)]; Grupo III, 11,9 [IC95% (8,08-15,7)] y Grupo IX, 4,3 [IC95% (1,94- 6,74)] (<xref ref-type="table" rid="t1">Tabla 1</xref>).</p>
+			<p>Al analizar el patrón geográfico de las tasas de incidencia, se observó que las tasas brutas más altas correspondían a las áreas de cobertura al sur y al oeste de la ciudad. También se calcularon las tasas de incidencia estandarizadas por edad en niñas, niños y adolescentes para el periodo, según área de cobertura de la unidad sanitaria. Se encontró un patrón geográfico acentuado, con la incidencia más baja en el norte y este de Campinas. La <xref ref-type="fig" rid="f1">Figura 1</xref> muestra que la razón de morbilidad estandarizada más alta está concentrada en las regiones suroeste y sureste de la municipalidad.</p>
+			<p>
+				<fig id="f1">
+					<label>Figura 1</label>
+					<caption>
+						<title>Razón de morbilidad estandarizada (RME) para cáncer en niñas, niños y adolescentes de 0 a 19 años de edad, según área de unidad sanitaria. Campinas, San Pablo, Brasil, 1996-2005</title>
+					</caption>
+					<graphic xlink:href="1851-8265-scol-14-01-51-gf1.jpg"/>
+					<attrib>Fuente: Elaboración propia con base en datos de la Unidad de Alta Complejidad de Oncología Pediátrica de Campinas</attrib>
+				</fig>
+			</p>
+			<p>Según el modelo que se describe arriba, hay un patrón geográfico acentuado, con menor distribución en el norte de la ciudad. Los riesgos relativos (RR) no fueron estadísticamente significativos entre las áreas de unidad sanitaria. Las <xref ref-type="fig" rid="f2">Figuras 2</xref> y <xref ref-type="fig" rid="f3">3</xref> muestran los RR para cáncer infantil y los intervalos de credibilidad del 95%. Aunque algunas de las áreas de cobertura al sur y al oeste presentaron tasas brutas de incidencia más altas, no se observaron diferencias estadísticamente significativas en los RR.</p>
+			<p>
+				<fig id="f2">
+					<label>Figura 2</label>
+					<caption>
+						<title>Riesgo relativo de cáncer estimado entre personas de 0 a 19 años según área de unidad sanitaria. Campinas, San Pablo, Brasil, 1996-2005</title>
+					</caption>
+					<graphic xlink:href="1851-8265-scol-14-01-51-gf2.jpg"/>
+					<attrib>Fuente: Elaboración propia con base en datos de la Unidad de Alta Complejidad de Oncología Pediátrica de Campinas</attrib>
+				</fig>
+			</p>
+			<p>
+				<fig id="f3">
+					<label>Figura 3</label>
+					<caption>
+						<title>Riesgo relativo estimado e intervalos de credibilidad del 95% en niñas, niños y adolescentes de 0 a 19 años según área de unidad sanitaria. Campinas, San Pablo, Brasil, 1996-2005</title>
+					</caption>
+					<graphic xlink:href="1851-8265-scol-14-01-51-gf3.jpg"/>
+					<attrib>Fuente: Elaboración propia con base en datos de la Unidad de Alta Complejidad de Oncología Pediátrica de Campinas</attrib>
+				</fig>
+			</p>
+		</sec>
+		<sec sec-type="discussion">
+			<title>DISCUSIÓN</title>
+			<p>Este estudio analiza el cáncer infantil en Campinas y utiliza el análisis espacial para examinar el patrón y la distribución de incidencia en la ciudad. El cáncer con mayor frecuencia ajustada por edad fue el Grupo I (Leucemia, 28,8 por millón), seguido por el Grupo III (Sistema nervioso central y miscelánea de neoplasias intracraneales e intraespinales, 11,9 por millón).</p>
+			<p>Dado que las características, la frecuencia y la distribución del tipo de cáncer en niñas, niños y adolescentes son diferentes a las observadas en cualquier otro grupo de edad, se ha recomendado que los estudios epidemiológicos de cáncer infantil se realizan de forma separada a los otros grupos de edad<xref ref-type="bibr" rid="B8"><sup>8</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B27"><sup>27</sup></xref>.</p>
+			<p>En Campinas -de modo similar a los resultados de informes previos que utilizaron registros europeos- el cáncer infantil más frecuente es el del Grupo I, que presentó tasas de incidencia más bajas que las observadas en la mayoría de los países europeos pero similares a las de Portugal (28 por millón), Polonia (29,9 por millón) y Rumanía (28,3 por millón)<xref ref-type="bibr" rid="B28"><sup>28</sup></xref>. Se ha sugerido que las tasas de cáncer infantil pueden reflejar el nivel de desarrollo socioeconómico de la sociedad, con tasas más altas en las sociedades más pudientes<xref ref-type="bibr" rid="B29"><sup>29</sup></xref>.</p>
+			<p>Sin embargo, encontramos que, en Campinas, los valores más altos de RME se concentran en las regiones del suroeste y sureste, las cuales corresponden a áreas de mayor desigualdad social en la ciudad. Este hallazgo puede estar relacionado con variables no observadas y merece mayor investigación. El tema del cáncer infantil no se puede evaluar de manera independiente al nivel de desarrollo y las condiciones de salud en cada región. El crecimiento poblacional, la pobreza, la falta de higiene, la falta de educación y una multitud de problemas de salud impiden el desarrollo de la oncología pediátrica y el éxito del manejo de cáncer infantil en los países en desarrollo<xref ref-type="bibr" rid="B29"><sup>29</sup></xref>.</p>
+			<p>Además, la distribución de los casos por sexo, edad y los cuatro grupos diagnósticos más frecuentes es similar a las encontradas en otros estudios brasile<bold>ñ</bold>os basados en 14 registros de cáncer con base poblacional<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>. Al contrastar nuestro análisis con publicaciones brasile<bold>ñ</bold>as previas sobre cáncer infantil, vemos que los cánceres del sistema nervioso central también fueron el segundo tumor infantil más frecuente observado<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>. </p>
+			<p>Las leucemias son el cáncer más frecuente en niños <bold>y</bold> niñas a nivel mundial y tienen el impacto más grande en la incidencia global de cáncer. Comparativamente, la incidencia más parecida a la encontrada en nuestro estudio fue el de África del Norte (28,2 por millón)<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>. Los diagnósticos más frecuentes en Campinas fueron las leucemias linfoblásticas agudas, las leucemias agudas no linfoblásticas, los astrocitomas y los linfomas de Hodgkin, tanto en niños <bold>y</bold> niñas como en adolescentes, hechos ya informados en la bibliografía<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B30"><sup>30</sup></xref>.</p>
+			<p>Según los registros encontrados para Sudamérica, solo la incidencia para el Grupo II fue similar a los hallazgos del presente estudio (11,6 por millón); para los otros tres grupos estudiados, la incidencia fue más alta en otros países de la región<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>.</p>
+			<p>En comparación con los países europeos, las diferencias más grandes en la incidencia se observaron para el Grupo III y el Grupo IX. En países europeos, las tasas de incidencia estandarizadas para el Grupo III (29,5 por millón) y el Grupo IX (9,4 por millón) son casi el doble de lo encontrado en Campinas (incidencia del Grupo II, 11,9 por millón y del Grupo IX, 4,3 por millón). Sin embargo, con relación al Grupo IX, la incidencia es semejante a la incidencia encontrada en Sudáfrica y en personas pertenecientes a los pueblos originarios en EE.UU.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B28"><sup>28</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B31"><sup>31</sup></xref>.</p>
+			<p>En nuestro estudio, estas diferencias se pueden explicar por el tipo de tumor (macizo) que afecta mayormente a adolescentes, quienes podrían haber recibido tratamiento en otra institución o haber sido considerados como adultos jóvenes y por ende no derivados a la Unidad de Alta Complejidad en Oncología Pediátrica.</p>
+			<p>Aunque las tasas de incidencia en los cuatro grupos diagnósticos difieren de las incidencias observadas a partir de los registros de cáncer con base poblacional de los países desarrollados, se asemejan a las encontradas en la bibliografía para los países en desarrollo, incluso Brasil<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B32"><sup>32</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B33"><sup>33</sup></xref>.</p>
+			<p>Una limitación de este estudio resulta de la fuente de datos, ya que los registros se obtuvieron de solo un servicio de oncología infantil. Aunque el Registro de Cáncer con Base Poblacional afirma que hay una cobertura del 85% en el caso de residentes de la ciudad, es posible que el perfil de pacientes no incluidos en el análisis difiera de lo observado en nuestros resultados.</p>
+			<p>Es necesario crear sistemas de monitoreo eficientes para cáncer, en particular, para los pocos casos de cáncer infantil. Su creación potenciaría el valor del análisis espacial al permitir resultados más precisos. A futuro se debería investigar la relación entre geografía y las tasas de incidencia por cáncer infantil para un espectro más amplio de medidas y resultados en salud<xref ref-type="bibr" rid="B16"><sup>16</sup></xref>.</p>
+			<p>Para concluir, nuestros resultados se condicen con informes previos de otros registros de cáncer. Esta aplicación de la incidencia de cáncer en una región de Brasil produjo evidencias de una distribución similar de cáncer entre niñas, niños y adolescentes. Este estudio de las tasas de incidencia de cáncer y el análisis de los patrones espaciales de las RME pueden ser centrales para definir programas de intervención en la región. Por lo tanto, puede aportar al desarrollo de programas de salud para la reducción de la morbilidad y la mortalidad en cáncer infantil y, de manera concomitante, a la planificación de intervenciones y la estructuración de la red sanitaria.</p>
+		</sec>
+	</body>
+	<back>
+		<ack>
+			<title>AGRADECIMIENTOS</title>
+			<p>A la Coordenação de Aperfeiçoamento de Pessoal de Nivel Superior de Brasil por el apoyo económico otorgado a la investigación (N° 99999.007495/2014-05), además de la importante contribución de investigadores de la Universidade do Porto y al Registro de Cáncer con Base Poblacional de Campinas.</p>
+		</ack>
+		<ref-list>
+			<title>REFERENCIAS BIBLIOGRÁFICAS</title>
+			<ref id="B1">
+				<label>1</label>
+				<mixed-citation>1. Brasil. Lei 8080, de 19 de setembro de 1990. Dispõe sobre as condições para a promoção, proteção e recuperação da saúde, a organização e o funcionamento dos serviços correspondentes e dá outras providências [Internet]. Diário Oficial da República Federativa do Brasil; 1990 [citado 2 May 2017]. Disponible en: <comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/d73vyv">https://tinyurl.com/d73vyv</ext-link>
+					</comment>.</mixed-citation>
+				<element-citation publication-type="legal-doc">
+					<person-group person-group-type="author">
+						<collab>Brasil</collab>
+					</person-group>
+					<article-title>Lei 8080, de 19 de setembro de 1990. Dispõe sobre as condições para a promoção, proteção e recuperação da saúde, a organização e o funcionamento dos serviços correspondentes e dá outras providências</article-title>
+					<source>Diário Oficial da República Federativa do Brasil</source>
+					<year>1990</year>
+					<date-in-citation content-type="access-date" iso-8601-date="2017-05-02">2 May 2017</date-in-citation>
+					<comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/d73vyv">https://tinyurl.com/d73vyv</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="B2">
+				<label>2</label>
+				<mixed-citation>2. Nunes ED. Collective health paradigms: a brief reflection. Salud Colectiva. 2014;10(1):57-65.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Nunes</surname>
+							<given-names>ED</given-names>
+						</name>
+					</person-group>
+					<article-title>Collective health paradigms: a brief reflection</article-title>
+					<source>Salud Colectiva</source>
+					<year>2014</year>
+					<volume>10</volume>
+					<issue>1</issue>
+					<fpage>57</fpage>
+					<lpage>65</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B3">
+				<label>3</label>
+				<mixed-citation>3. Breilh J. Epidemiologia: economia, política e saúde. São Paulo: Unesp-Hucitec; 1991.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Breilh</surname>
+							<given-names>J</given-names>
+						</name>
+					</person-group>
+					<source>Epidemiologia: economia, política e saúde</source>
+					<publisher-loc>São Paulo</publisher-loc>
+					<publisher-name>Unesp-Hucitec</publisher-name>
+					<year>1991</year>
+				</element-citation>
+			</ref>
+			<ref id="B4">
+				<label>4</label>
+				<mixed-citation>4. Guimarães RB. Geografia e saúde coletiva no Brasil. Saúde e Sociedade. 2016;25(4):869-879.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Guimarães</surname>
+							<given-names>RB</given-names>
+						</name>
+					</person-group>
+					<article-title>Geografia e saúde coletiva no Brasil</article-title>
+					<source>Saúde e Sociedade</source>
+					<year>2016</year>
+					<volume>25</volume>
+					<issue>4</issue>
+					<fpage>869</fpage>
+					<lpage>879</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B5">
+				<label>5</label>
+				<mixed-citation>5. Barcellos C. A Geografia e o Contexto dos Problemas de Saúde. Rio de Janeiro: Abrasco; 2008.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Barcellos</surname>
+							<given-names>C</given-names>
+						</name>
+					</person-group>
+					<source>A Geografia e o Contexto dos Problemas de Saúde</source>
+					<publisher-loc>Rio de Janeiro</publisher-loc>
+					<publisher-name>Abrasco</publisher-name>
+					<year>2008</year>
+				</element-citation>
+			</ref>
+			<ref id="B6">
+				<label>6</label>
+				<mixed-citation>6. De Camargo B, De Oliveira Santos M, Rebelo MS, De Souza Reis R, Ferman S, Noronha CP, Pombo-de-Oliveira MS. Cancer incidence among children and adolescents in Brazil: first report of 14 population-based cancer registries. International Journal of Cancer. 2010;126(3):715-720.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>De Camargo</surname>
+							<given-names>B</given-names>
+						</name>
+						<name>
+							<surname>De Oliveira Santos</surname>
+							<given-names>M</given-names>
+						</name>
+						<name>
+							<surname>Rebelo</surname>
+							<given-names>MS</given-names>
+						</name>
+						<name>
+							<surname>De Souza Reis</surname>
+							<given-names>R</given-names>
+						</name>
+						<name>
+							<surname>Ferman</surname>
+							<given-names>S</given-names>
+						</name>
+						<name>
+							<surname>Noronha</surname>
+							<given-names>CP</given-names>
+						</name>
+						<name>
+							<surname>Pombo-de-Oliveira</surname>
+							<given-names>MS</given-names>
+						</name>
+					</person-group>
+					<article-title>Cancer incidence among children and adolescents in Brazil: first report of 14 population-based cancer registries</article-title>
+					<source>International Journal of Cancer</source>
+					<year>2010</year>
+					<volume>126</volume>
+					<issue>3</issue>
+					<fpage>715</fpage>
+					<lpage>720</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B7">
+				<label>7</label>
+				<mixed-citation>7. Steliarova-Foucher E, Colombet M, Ries LAG, Moreno F, Dolya A, Bray F, Hesseling P, Shin HY, Stiller CA, IICC-3 contributors. International incidence of childhood cancer, 2001-10: a population-based registry study. The Lancet Oncology. 2017;18(6):719-731.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Colombet</surname>
+							<given-names>M</given-names>
+						</name>
+						<name>
+							<surname>Ries</surname>
+							<given-names>LAG</given-names>
+						</name>
+						<name>
+							<surname>Moreno</surname>
+							<given-names>F</given-names>
+						</name>
+						<name>
+							<surname>Dolya</surname>
+							<given-names>A</given-names>
+						</name>
+						<name>
+							<surname>Bray</surname>
+							<given-names>F</given-names>
+						</name>
+						<name>
+							<surname>Hesseling</surname>
+							<given-names>P</given-names>
+						</name>
+						<name>
+							<surname>Shin</surname>
+							<given-names>HY</given-names>
+						</name>
+						<name>
+							<surname>Stiller</surname>
+							<given-names>CA</given-names>
+						</name>
+						<collab>IICC-3 contributors</collab>
+					</person-group>
+					<article-title>International incidence of childhood cancer, 2001-10: a population-based registry study</article-title>
+					<source>The Lancet Oncology</source>
+					<year>2017</year>
+					<volume>18</volume>
+					<issue>6</issue>
+					<fpage>719</fpage>
+					<lpage>731</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B8">
+				<label>8</label>
+				<mixed-citation>8. Magrath I, Steliarova-Foucher E , Epelman S, Ribeiro RC, Harif M, Li CK, Kebudi R, Macfarlane SD, Howard SC. Paediatric cancer in low-income and middle-income countries. The Lancet Oncology. 2013;14(3):e104-e116.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Magrath</surname>
+							<given-names>I</given-names>
+						</name>
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Epelman</surname>
+							<given-names>S</given-names>
+						</name>
+						<name>
+							<surname>Ribeiro</surname>
+							<given-names>RC</given-names>
+						</name>
+						<name>
+							<surname>Harif</surname>
+							<given-names>M</given-names>
+						</name>
+						<name>
+							<surname>Li</surname>
+							<given-names>CK</given-names>
+						</name>
+						<name>
+							<surname>Kebudi</surname>
+							<given-names>R</given-names>
+						</name>
+						<name>
+							<surname>Macfarlane</surname>
+							<given-names>SD</given-names>
+						</name>
+						<name>
+							<surname>Howard</surname>
+							<given-names>SC</given-names>
+						</name>
+					</person-group>
+					<article-title>Paediatric cancer in low-income and middle-income countries</article-title>
+					<source>The Lancet Oncology</source>
+					<year>2013</year>
+					<volume>14</volume>
+					<issue>3</issue>
+					<fpage>e104</fpage>
+					<lpage>e116</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B9">
+				<label>9</label>
+				<mixed-citation>9. Forman D, Bray F , Brewster DH, Gombe Mbalawa C, Kohler B, Piñeros M, Steliarova-Foucher E , Swaminathan R, Ferlay J, editors. Cancer incidence in five continents Vol-X [Internet]. Lyon: International Agency for Research on Cancer; 2014 [citado 12 oct 2016]. Disponible en: <comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/y8z9w5rk">https://tinyurl.com/y8z9w5rk</ext-link>
+					</comment>.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="editor">
+						<name>
+							<surname>Forman</surname>
+							<given-names>D</given-names>
+						</name>
+						<name>
+							<surname>Bray</surname>
+							<given-names>F</given-names>
+						</name>
+						<name>
+							<surname>Brewster</surname>
+							<given-names>DH</given-names>
+						</name>
+						<name>
+							<surname>Gombe Mbalawa</surname>
+							<given-names>C</given-names>
+						</name>
+						<name>
+							<surname>Kohler</surname>
+							<given-names>B</given-names>
+						</name>
+						<name>
+							<surname>Piñeros</surname>
+							<given-names>M</given-names>
+						</name>
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Swaminathan</surname>
+							<given-names>R</given-names>
+						</name>
+						<name>
+							<surname>Ferlay</surname>
+							<given-names>J</given-names>
+						</name>
+					</person-group>
+					<source>Cancer incidence in five continents Vol-X</source>
+					<publisher-loc>Lyon</publisher-loc>
+					<publisher-name>International Agency for Research on Cancer</publisher-name>
+					<year>2014</year>
+					<date-in-citation content-type="access-date" iso-8601-date="2016-10-12">12 oct 2016</date-in-citation>
+					<comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/y8z9w5rk">https://tinyurl.com/y8z9w5rk</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="B10">
+				<label>10</label>
+				<mixed-citation>10. Parkin DM, Kramárová E, Draper GJ, Masuyer E, editors. International Incidence of Childhood Cancer. No.114. Lyon: IARC Scientific Publication; 1998.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="editor">
+						<name>
+							<surname>Parkin</surname>
+							<given-names>DM</given-names>
+						</name>
+						<name>
+							<surname>Kramárová</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Draper</surname>
+							<given-names>GJ</given-names>
+						</name>
+						<name>
+							<surname>Masuyer</surname>
+							<given-names>E</given-names>
+						</name>
+					</person-group>
+					<source>International Incidence of Childhood Cancer</source>
+					<issue>114</issue>
+					<publisher-loc>Lyon</publisher-loc>
+					<publisher-name>IARC Scientific Publication</publisher-name>
+					<year>1998</year>
+				</element-citation>
+			</ref>
+			<ref id="B11">
+				<label>11</label>
+				<mixed-citation>11. Teixeira RP, Ramalho WS, Fernandes ICF, Salge AKM, Barbosa MA, Siqueira KM. A Família da criança com câncer: percepções de profissionais de enfermagem atuantes em oncologia pediátrica. Ciência, Cuidado e Saúde. 2012;11(4):784-791.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Teixeira</surname>
+							<given-names>RP</given-names>
+						</name>
+						<name>
+							<surname>Ramalho</surname>
+							<given-names>WS</given-names>
+						</name>
+						<name>
+							<surname>Fernandes</surname>
+							<given-names>ICF</given-names>
+						</name>
+						<name>
+							<surname>Salge</surname>
+							<given-names>AKM</given-names>
+						</name>
+						<name>
+							<surname>Barbosa</surname>
+							<given-names>MA</given-names>
+						</name>
+						<name>
+							<surname>Siqueira</surname>
+							<given-names>KM</given-names>
+						</name>
+					</person-group>
+					<article-title>A Família da criança com câncer: percepções de profissionais de enfermagem atuantes em oncologia pediátrica</article-title>
+					<source>Ciência, Cuidado e Saúde</source>
+					<year>2012</year>
+					<volume>11</volume>
+					<issue>4</issue>
+					<fpage>784</fpage>
+					<lpage>791</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B12">
+				<label>12</label>
+				<mixed-citation>12. Instituto Brasileiro de Geografia e Estatística. Infográficos [Internet]. Brasil: IBGE; 2010 [citado 02 May 2017]. Disponible en: <comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/ybqtotu2">https://tinyurl.com/ybqtotu2</ext-link>
+					</comment>.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<collab>Instituto Brasileiro de Geografia e Estatística</collab>
+					</person-group>
+					<source>Infográficos</source>
+					<publisher-loc>Brasil</publisher-loc>
+					<publisher-name>IBGE</publisher-name>
+					<year>2010</year>
+					<date-in-citation content-type="access-date" iso-8601-date="2017-05-02">02 May 2017</date-in-citation>
+					<comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://tinyurl.com/ybqtotu2">https://tinyurl.com/ybqtotu2</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="B13">
+				<label>13</label>
+				<mixed-citation>13. Grabois MF, Oliveira EXG, Carvalho MS. Childhood cancer and pediatric oncologic care in Brazil: access and equity. Cadernos de Saúde Pública. 2011;27:1711-1720.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Grabois</surname>
+							<given-names>MF</given-names>
+						</name>
+						<name>
+							<surname>Oliveira</surname>
+							<given-names>EXG</given-names>
+						</name>
+						<name>
+							<surname>Carvalho</surname>
+							<given-names>MS</given-names>
+						</name>
+					</person-group>
+					<article-title>Childhood cancer and pediatric oncologic care in Brazil: access and equity</article-title>
+					<source>Cadernos de Saúde Pública</source>
+					<year>2011</year>
+					<volume>27</volume>
+					<fpage>1711</fpage>
+					<lpage>1720</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B14">
+				<label>14</label>
+				<mixed-citation>14. Mutti CF, Paula CC, Souto MD. Assistência à Saúde da Criança com Câncer na Produção Científica Brasileira. Revista Brasileira de Cancerologia. 2010;1(56):71-83.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Mutti</surname>
+							<given-names>CF</given-names>
+						</name>
+						<name>
+							<surname>Paula</surname>
+							<given-names>CC</given-names>
+						</name>
+						<name>
+							<surname>Souto</surname>
+							<given-names>MD</given-names>
+						</name>
+					</person-group>
+					<article-title>Assistência à Saúde da Criança com Câncer na Produção Científica Brasileira</article-title>
+					<source>Revista Brasileira de Cancerologia</source>
+					<year>2010</year>
+					<volume>1</volume>
+					<issue>56</issue>
+					<fpage>71</fpage>
+					<lpage>83</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B15">
+				<label>15</label>
+				<mixed-citation>15. Scott D, Curtis B, Twumasi FO. Towards the creation of a health information system for cancer in KwaZulu-Natal, South Africa. Health &amp; Place. 2002;8(4):237-249.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Scott</surname>
+							<given-names>D</given-names>
+						</name>
+						<name>
+							<surname>Curtis</surname>
+							<given-names>B</given-names>
+						</name>
+						<name>
+							<surname>Twumasi</surname>
+							<given-names>FO</given-names>
+						</name>
+					</person-group>
+					<article-title>Towards the creation of a health information system for cancer in KwaZulu-Natal, South Africa</article-title>
+					<source>Health &amp; Place</source>
+					<year>2002</year>
+					<volume>8</volume>
+					<issue>4</issue>
+					<fpage>237</fpage>
+					<lpage>249</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B16">
+				<label>16</label>
+				<mixed-citation>16. Bailony MR, Hararah MK, Salhab AR, Ghannam I, Abdeen Z, Ghannam J. Cancer registration and healthcare access in West Bank, Palestine: a GIS analysis of childhood cancer, 1998-2007. International Journal of Cancer. 2011;129(5):1180-1189.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Bailony</surname>
+							<given-names>MR</given-names>
+						</name>
+						<name>
+							<surname>Hararah</surname>
+							<given-names>MK</given-names>
+						</name>
+						<name>
+							<surname>Salhab</surname>
+							<given-names>AR</given-names>
+						</name>
+						<name>
+							<surname>Ghannam</surname>
+							<given-names>I</given-names>
+						</name>
+						<name>
+							<surname>Abdeen</surname>
+							<given-names>Z</given-names>
+						</name>
+						<name>
+							<surname>Ghannam</surname>
+							<given-names>J</given-names>
+						</name>
+					</person-group>
+					<article-title>Cancer registration and healthcare access in West Bank, Palestine: a GIS analysis of childhood cancer, 1998-2007</article-title>
+					<source>International Journal of Cancer</source>
+					<year>2011</year>
+					<volume>129</volume>
+					<issue>5</issue>
+					<fpage>1180</fpage>
+					<lpage>1189</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B17">
+				<label>17</label>
+				<mixed-citation>17. Friestino JKO. Panorama do câncer em crianças e adolescentes sob a perspectiva da saúde coletiva. [Teses de Doutorado]. Campinas: Universidade Estadual de Campinas; 2015.</mixed-citation>
+				<element-citation publication-type="thesis">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Friestino</surname>
+							<given-names>JKO</given-names>
+						</name>
+					</person-group>
+					<source>Panorama do câncer em crianças e adolescentes sob a perspectiva da saúde coletiva</source>
+					<comment content-type="degree">Teses de Doutorado</comment>
+					<publisher-loc>Campinas</publisher-loc>
+					<publisher-name>Universidade Estadual de Campinas</publisher-name>
+					<year>2015</year>
+				</element-citation>
+			</ref>
+			<ref id="B18">
+				<label>18</label>
+				<mixed-citation>18. Oliveira-Friestino JK, Francisco PMB, Moreira Filho DC. Incidence profile of leukemias, lymphomas, central nervous system tumors and soft-tissue sarcomas in children and adolescents in a brazilian city. International Archives of Medicine. 2016;9(152):1-8.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Oliveira-Friestino</surname>
+							<given-names>JK</given-names>
+						</name>
+						<name>
+							<surname>Francisco</surname>
+							<given-names>PMB</given-names>
+						</name>
+						<name>
+							<surname>Moreira</surname>
+							<given-names>DC</given-names>
+							<suffix>Filho</suffix>
+						</name>
+					</person-group>
+					<article-title>Incidence profile of leukemias, lymphomas, central nervous system tumors and soft-tissue sarcomas in children and adolescents in a brazilian city</article-title>
+					<source>International Archives of Medicine</source>
+					<year>2016</year>
+					<volume>9</volume>
+					<issue>152</issue>
+					<fpage>1</fpage>
+					<lpage>8</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B19">
+				<label>19</label>
+				<mixed-citation>19. Steliarova-Foucher E , Stiller C, Lacour B, Kaatsch P. International Classification of Childhood Cancer, Third Edition. Cancer. 2005;103(7):1457-1467.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Stiller</surname>
+							<given-names>C</given-names>
+						</name>
+						<name>
+							<surname>Lacour</surname>
+							<given-names>B</given-names>
+						</name>
+						<name>
+							<surname>Kaatsch</surname>
+							<given-names>P</given-names>
+						</name>
+					</person-group>
+					<article-title>Classification of Childhood Cancer, Third Edition</article-title>
+					<source>Cancer</source>
+					<year>2005</year>
+					<volume>103</volume>
+					<issue>7</issue>
+					<fpage>1457</fpage>
+					<lpage>1467</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B20">
+				<label>20</label>
+				<mixed-citation>20. Doll R, Payne P, Waterhouse JAH, editors. Cancer incidence in five continents. Geneva: Union Internationale Contre le Cancer; 1966.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="editor">
+						<name>
+							<surname>Doll</surname>
+							<given-names>R</given-names>
+						</name>
+						<name>
+							<surname>Payne</surname>
+							<given-names>P</given-names>
+						</name>
+						<name>
+							<surname>Waterhouse</surname>
+							<given-names>JAH</given-names>
+						</name>
+					</person-group>
+					<source>Cancer incidence in five continents</source>
+					<publisher-loc>Geneva</publisher-loc>
+					<publisher-name>Union Internationale Contre le Cancer</publisher-name>
+					<year>1966</year>
+				</element-citation>
+			</ref>
+			<ref id="B21">
+				<label>21</label>
+				<mixed-citation>21. Clayton D, Kaldor J. Empirical Bayes estimates of age-standardized relative risks for use in disease mapping. Biometrics. 1987;43(3):671-681.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Clayton</surname>
+							<given-names>D</given-names>
+						</name>
+						<name>
+							<surname>Kaldor</surname>
+							<given-names>J</given-names>
+						</name>
+					</person-group>
+					<article-title>Empirical Bayes estimates of age-standardized relative risks for use in disease mapping</article-title>
+					<source>Biometrics</source>
+					<year>1987</year>
+					<volume>43</volume>
+					<issue>3</issue>
+					<fpage>671</fpage>
+					<lpage>681</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B22">
+				<label>22</label>
+				<mixed-citation>22. Bailey TC. Spatial statistical methods in health. Cadernos de Saúde Pública. 2001;17:1083-1098.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Bailey</surname>
+							<given-names>TC</given-names>
+						</name>
+					</person-group>
+					<article-title>Spatial statistical methods in health</article-title>
+					<source>Cadernos de Saúde Pública</source>
+					<year>2001</year>
+					<volume>17</volume>
+					<fpage>1083</fpage>
+					<lpage>1098</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B23">
+				<label>23</label>
+				<mixed-citation>23. Gelfand AE, Vounatsou P. Proper multivariate conditional autoregressive models for spatial data analysis. Biostatistics. 2003;4(1):11-25.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Gelfand</surname>
+							<given-names>AE</given-names>
+						</name>
+						<name>
+							<surname>Vounatsou</surname>
+							<given-names>P</given-names>
+						</name>
+					</person-group>
+					<article-title>Proper multivariate conditional autoregressive models for spatial data analysis</article-title>
+					<source>Biostatistics</source>
+					<year>2003</year>
+					<volume>4</volume>
+					<issue>1</issue>
+					<fpage>11</fpage>
+					<lpage>25</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B24">
+				<label>24</label>
+				<mixed-citation>24. Oliveira CM, Economou T, Bailey T, Mendonca D, Pina MF. The interactions between municipal socioeconomic status and age on hip fracture risk. Osteoporosis International. 2015;26(2):489-498.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Oliveira</surname>
+							<given-names>CM</given-names>
+						</name>
+						<name>
+							<surname>Economou</surname>
+							<given-names>T</given-names>
+						</name>
+						<name>
+							<surname>Bailey</surname>
+							<given-names>T</given-names>
+						</name>
+						<name>
+							<surname>Mendonca</surname>
+							<given-names>D</given-names>
+						</name>
+						<name>
+							<surname>Pina</surname>
+							<given-names>MF</given-names>
+						</name>
+					</person-group>
+					<article-title>The interactions between municipal socioeconomic status and age on hip fracture risk</article-title>
+					<source>Osteoporosis International</source>
+					<year>2015</year>
+					<volume>26</volume>
+					<issue>2</issue>
+					<fpage>489</fpage>
+					<lpage>498</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B25">
+				<label>25</label>
+				<mixed-citation>25. Lunn DJ, Thomas A, Best N, Spiegelhalter D. WinBUGS-a Bayesian modelling framework: concepts, structure, and extensibility. Statistics and Computing. 2000;10(4):325-337.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Lunn</surname>
+							<given-names>DJ</given-names>
+						</name>
+						<name>
+							<surname>Thomas</surname>
+							<given-names>A</given-names>
+						</name>
+						<name>
+							<surname>Best</surname>
+							<given-names>N</given-names>
+						</name>
+						<name>
+							<surname>Spiegelhalter</surname>
+							<given-names>D</given-names>
+						</name>
+					</person-group>
+					<article-title>WinBUGS-a Bayesian modelling framework: concepts, structure, and extensibility</article-title>
+					<source>Statistics and Computing</source>
+					<year>2000</year>
+					<volume>10</volume>
+					<issue>4</issue>
+					<fpage>325</fpage>
+					<lpage>337</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B26">
+				<label>26</label>
+				<mixed-citation>26. RC Team. R: a language and environment for statistical computing [Internet]. Austria: R Foundation for Statistical Computing; 2012 [citado 16 oct 2016]. Disponible en: <comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://www.r-project.org/">https://www.r-project.org/</ext-link>
+					</comment>.</mixed-citation>
+				<element-citation publication-type="software">
+					<person-group person-group-type="author">
+						<collab>RC Team</collab>
+					</person-group>
+					<source>R: a language and environment for statistical computing</source>
+					<publisher-loc>Austria</publisher-loc>
+					<publisher-name>R Foundation for Statistical Computing</publisher-name>
+					<year>2012</year>
+					<date-in-citation content-type="access-date" iso-8601-date="2016-10-16">16 oct 2016</date-in-citation>
+					<comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://www.r-project.org/">https://www.r-project.org/</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="B27">
+				<label>27</label>
+				<mixed-citation>27. Carreira H, Antunes L, Castro C, Lunet N, Bento MJ. Cancer incidence and survival (1997-2006) among adolescents and young adults in the north of Portugal. Pediatric Hematology and Oncology. 2012;29(7):663-676.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Carreira</surname>
+							<given-names>H</given-names>
+						</name>
+						<name>
+							<surname>Antunes</surname>
+							<given-names>L</given-names>
+						</name>
+						<name>
+							<surname>Castro</surname>
+							<given-names>C</given-names>
+						</name>
+						<name>
+							<surname>Lunet</surname>
+							<given-names>N</given-names>
+						</name>
+						<name>
+							<surname>Bento</surname>
+							<given-names>MJ</given-names>
+						</name>
+					</person-group>
+					<article-title>Cancer incidence and survival (1997-2006) among adolescents and young adults in the north of Portugal</article-title>
+					<source>Pediatric Hematology and Oncology</source>
+					<year>2012</year>
+					<volume>29</volume>
+					<issue>7</issue>
+					<fpage>663</fpage>
+					<lpage>676</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B28">
+				<label>28</label>
+				<mixed-citation>28. International Agency for Research on Cancer. World Cancer Report 2014. Lyon: WHO; 2014.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<collab>International Agency for Research on Cancer</collab>
+					</person-group>
+					<source>World Cancer Report 2014</source>
+					<publisher-loc>Lyon</publisher-loc>
+					<publisher-name>WHO</publisher-name>
+					<year>2014</year>
+				</element-citation>
+			</ref>
+			<ref id="B29">
+				<label>29</label>
+				<mixed-citation>29. Yaris N, Mandiracioglu A, Büyükpamukcuc M. Childhood cancer in developing countries. Pediatric Hematology and Oncology. 2004;21(3):237-253.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Yaris</surname>
+							<given-names>N</given-names>
+						</name>
+						<name>
+							<surname>Mandiracioglu</surname>
+							<given-names>A</given-names>
+						</name>
+						<name>
+							<surname>Büyükpamukcuc</surname>
+							<given-names>M</given-names>
+						</name>
+					</person-group>
+					<article-title>Childhood cancer in developing countries</article-title>
+					<source>Pediatric Hematology and Oncology</source>
+					<year>2004</year>
+					<volume>21</volume>
+					<issue>3</issue>
+					<fpage>237</fpage>
+					<lpage>253</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B30">
+				<label>30</label>
+				<mixed-citation>30. Steliarova-Foucher E, Stiller C, Kaatsch P, Berrino F, Coebergh JW, Lacour B, Parkin M. Geographical patterns and time trends of cancer incidence and survival among children and adolescents in Europe since the 1970s (the ACCIS project): an epidemiological study. Lancet. 2004;364(9451):2097-2105.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Stiller</surname>
+							<given-names>C</given-names>
+						</name>
+						<name>
+							<surname>Kaatsch</surname>
+							<given-names>P</given-names>
+						</name>
+						<name>
+							<surname>Berrino</surname>
+							<given-names>F</given-names>
+						</name>
+						<name>
+							<surname>Coebergh</surname>
+							<given-names>JW</given-names>
+						</name>
+						<name>
+							<surname>Lacour</surname>
+							<given-names>B</given-names>
+						</name>
+						<name>
+							<surname>Parkin</surname>
+							<given-names>M</given-names>
+						</name>
+					</person-group>
+					<article-title>Geographical patterns and time trends of cancer incidence and survival among children and adolescents in Europe since the 1970s (the ACCIS project): an epidemiological study</article-title>
+					<source>Lancet</source>
+					<year>2004</year>
+					<volume>364</volume>
+					<issue>9451</issue>
+					<fpage>2097</fpage>
+					<lpage>2105</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B31">
+				<label>31</label>
+				<mixed-citation>31. Stiller CA, Desandes E, Danon SE, Izarzugaza I, Ratiu A, Vassileva-Valerianova Z, Steliarova-Foucher E. Cancer incidence and survival in European adolescents (1978-1997). European Journal of Cancer. 2006;42(13):2006-2018.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Stiller</surname>
+							<given-names>CA</given-names>
+						</name>
+						<name>
+							<surname>Desandes</surname>
+							<given-names>E</given-names>
+						</name>
+						<name>
+							<surname>Danon</surname>
+							<given-names>SE</given-names>
+						</name>
+						<name>
+							<surname>Izarzugaza</surname>
+							<given-names>I</given-names>
+						</name>
+						<name>
+							<surname>Ratiu</surname>
+							<given-names>A</given-names>
+						</name>
+						<name>
+							<surname>Vassileva-Valerianova</surname>
+							<given-names>Z</given-names>
+						</name>
+						<name>
+							<surname>Steliarova-Foucher</surname>
+							<given-names>E</given-names>
+						</name>
+					</person-group>
+					<article-title>Cancer incidence and survival in European adolescents (1978-1997)</article-title>
+					<source>European Journal of Cancer</source>
+					<year>2006</year>
+					<volume>42</volume>
+					<issue>13</issue>
+					<fpage>2006</fpage>
+					<lpage>2018</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B32">
+				<label>32</label>
+				<mixed-citation>32. Braga PE, Latorre MRDO, Curado MP. Childhood cancer: a comparative analysis of incidence, mortality, and survival in Goiania (Brazil) and other countries. Cadernos de Saúde Pública. 2002;18(1):33-44.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Braga</surname>
+							<given-names>PE</given-names>
+						</name>
+						<name>
+							<surname>Latorre</surname>
+							<given-names>MRDO</given-names>
+						</name>
+						<name>
+							<surname>Curado</surname>
+							<given-names>MP</given-names>
+						</name>
+					</person-group>
+					<article-title>Childhood cancer: a comparative analysis of incidence, mortality, and survival in Goiania (Brazil) and other countries</article-title>
+					<source>Cadernos de Saúde Pública</source>
+					<year>2002</year>
+					<volume>18</volume>
+					<issue>1</issue>
+					<fpage>33</fpage>
+					<lpage>44</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B33">
+				<label>33</label>
+				<mixed-citation>33. Balmant NV, Reis RDS, Oliveira JFP, Ferman S, Santos MDO, Camargo BD. Cancer incidence among adolescents and young adults (15 to 29 years) in Brazil. Pediatric Hematology and Oncology. 2016;8(3):e88-96.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Balmant</surname>
+							<given-names>NV</given-names>
+						</name>
+						<name>
+							<surname>Reis</surname>
+							<given-names>RDS</given-names>
+						</name>
+						<name>
+							<surname>Oliveira</surname>
+							<given-names>JFP</given-names>
+						</name>
+						<name>
+							<surname>Ferman</surname>
+							<given-names>S</given-names>
+						</name>
+						<name>
+							<surname>Santos</surname>
+							<given-names>MDO</given-names>
+						</name>
+						<name>
+							<surname>Camargo</surname>
+							<given-names>BD</given-names>
+						</name>
+					</person-group>
+					<article-title>Cancer incidence among adolescents and young adults (15 to 29 years) in Brazil</article-title>
+					<source>Pediatric Hematology and Oncology</source>
+					<year>2016</year>
+					<volume>8</volume>
+					<issue>3</issue>
+					<fpage>e88</fpage>
+					<lpage>e96</lpage>
+				</element-citation>
+			</ref>
+		</ref-list>
+	</back>
+	<sub-article article-type="translation" id="s1" xml:lang="en">
+		<front-stub>
+			<article-categories>
+				<subj-group subj-group-type="heading">
+					<subject>ARTICLES</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>Childhood cancer: incidence and spatial patterns in the city of Campinas, Brazil, 1996-2005</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-5432-9560</contrib-id>
+					<name>
+						<surname>Oliveira Friestino</surname>
+						<given-names>Jane Kelly</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff6"><sup>1</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0003-4835-8944</contrib-id>
+					<name>
+						<surname>Mendonça</surname>
+						<given-names>Denisa</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff7"><sup>2</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">http://orcid.org/0000-0002-2470-0795</contrib-id>
+					<name>
+						<surname>Oliveira</surname>
+						<given-names>Pedro</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff8"><sup>3</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-4594-1723</contrib-id>
+					<name>
+						<surname>Oliveira</surname>
+						<given-names>Carla M</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff9"><sup>4</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-7943-0868</contrib-id>
+					<name>
+						<surname>de Carvalho Moreira</surname>
+						<given-names>Djalma</given-names>
+						<suffix>Filho</suffix>
+					</name>
+					<xref ref-type="aff" rid="aff10"><sup>5</sup></xref>
+				</contrib>
+			</contrib-group>
+			<aff id="aff6">
+				<label>1</label>
+				<institution content-type="original">PhD in Collective Health. Professor, Universidade Federal da Fronteira Sul, Chapecó, Brazil. jane.friestino@uffs.edu.br</institution>
+			</aff>
+			<aff id="aff7">
+				<label>2</label>
+				<institution content-type="original">PhD in Biostatistics, Professor, Epidemiology Research Unit, Instituto de Saúde Pública, Instituto de Ciências Biomédicas Abel Salazar, Universidade do Porto, Portugal. dvmendon@icbas.up.pt</institution>
+			</aff>
+			<aff id="aff8">
+				<label>3</label>
+				<institution content-type="original">PhD in Biostatistics. Profesor, Epidemiology Research Unit, Instituto de Saúde Pública, Instituto de Ciências Biomédicas Abel Salazar, Universidade do Porto, Portugal. pnoliveira@icbas.up.pt</institution>
+			</aff>
+			<aff id="aff9">
+				<label>4</label>
+				<institution content-type="original">PhD in Public Health. Invited Assistant Professor, Escola Superior de Saúde, Instituto Politécnico do Porto. Researcher, Instituto de Investigação e Inovação em Saúde (i3s), Instituto de Engenharia Biomédica, Universidade do Porto, Portugal. carlaoliver@gmail.com</institution>
+			</aff>
+			<aff id="aff10">
+				<label>5</label>
+				<institution content-type="original">PhD in Preventive Medicine. Professor, Universidade Estadual de Campinas, Brazil. djalmore@unicamp.br</institution>
+			</aff>
+			<abstract>
+				<title>ABSTRACT </title>
+				<p>This article analyzes cancer incidence and spatial patterns in children and adolescents (0-19 years of age) residing in the city of Campinas in Southeastern Brazil who were diagnosed from 1996-2005. Cancers were classified according to the Third International Classification of Childhood Cancer (ICCC-3) Groups. The four most common groups were studied: leukemias, lymphomas, and central nervous system and soft tissue neoplasms. Age-standardized incidence rates were calculated using the world standard population. A spatial Bayesian hierarchical regression model (controlling for data heterogeneity and spatial autocorrelation) was fitted, assuming that the number of cancer cases follows a Poisson distribution. A total of 180 cases were diagnosed during the study period. Overall, the crude incidence rate was 54.2 per million and the age-standardized incidence rate was 56.5 per million. Although some regions present higher incidence rates, considering the spatial heterogeneity and the spatial autocorrelation, no statistically significant differences in the relative risks were observed. </p>
+			</abstract>
+			<kwd-group xml:lang="en">
+				<title>KEY WORDS: </title>
+				<kwd>Spatial Analysis</kwd>
+				<kwd>Neoplasms</kwd>
+				<kwd>Child Health</kwd>
+				<kwd>Adolescent Health</kwd>
+				<kwd>Medical Geography</kwd>
+				<kwd>Brazil</kwd>
+			</kwd-group>
+		</front-stub>
+		<body>
+			<sec>
+				<title>BACKGROUND</title>
+				<p>The Unified Health System (SUS), as an integral part of the Brazilian system of social protection, has among its objectives to identify health factors and determinants and to use indicators to describe the situations of health and wellbeing of the population.<xref ref-type="bibr" rid="B1"><sup>1</sup></xref>
+				</p>
+				<p>In this scenario, collective health in Brazil has undergone some restructuring since the health reform that occurred in the mid-1970s. Based on conceptions of social medicine, collective health is currently constituted as a scientific field that contributes to studies of the health-disease-care process in diverse population groups inserted into specific geographical, historical and social contexts.<xref ref-type="bibr" rid="B2"><sup>2</sup></xref>
+				</p>
+				<p>Present-day epidemiology, particularly social epidemiology, has moved beyond the explanatory models of the health-disease process of the 1970s. Epidemiology now includes in its research methods expertise from other areas of knowledge, and therefore contemplates important elements such as the complexity existing in the various cycles of human life, which brings together the space and time in which individuals are inserted.<xref ref-type="bibr" rid="B3"><sup>3</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B4"><sup>4</sup></xref>
+				</p>
+				<p>From the perspective of social epidemiology, health is considered a relevant component of the well-being of not only the individual but also of society, as an essential condition for the enjoyment of life and an inalienable right of people regardless of where they live. Shifts in the overall structure of society, climate change, the aging of the population, the growth of inequality, and access to health care are some of the issues that have motivated the awakening of a new awareness of the importance of the territory and geography in the analysis of health conditions, prompting this area of knowledge to gain relevance in the field of collective health.</p>
+				<p>According to Barcellos,<xref ref-type="bibr" rid="B5"><sup>5</sup></xref><sup>)</sup> the geography of health </p>
+				<disp-quote>
+					<p>...is a field of knowledge that must integrate specialists and professionals interested in studying health-disease-care processes in geographic space, so as to intervene.</p>
+				</disp-quote>
+				<p>Currently in the literature it is possible to find a large number of studies that analyze chronic and non-communicable diseases, in particular the occurrence of neoplasms.<xref ref-type="bibr" rid="B4"><sup>4</sup></xref>
+				</p>
+				<p>As they are considered multifactorial diseases, various factors influence the geographic distribution of neoplasms, especially social determinants, the environment and access to health services. An essential tool for the epidemiological surveillance of cancer incidence involves the use of population-based cancer registries (PBCR); such registries are fundamental sources for the development of epidemiological research and clinics, as well as for the planning and evaluation of actions to cancer control.</p>
+				<p>Given the importance of knowing the incidence of cancer in the population, since the 1980s the National Institute of Cancer [<italic>Instituto Nacional de Câncer</italic>] has promoted the establishment of cancer registries in Brazil, such that there are now 20 population-based cancer registries distributed in major cities of all regions of the country.<xref ref-type="bibr" rid="B6"><sup>6</sup></xref> The majority of research is geared towards the types of neoplasms with greatest incidence, perhaps because of the ease in obtaining the data or because of the large amount of information needed for contingency planning; studies of rare cases are therefore scarce in the literature.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>
+				</p>
+				<p>Campinas, a large Brazilian city located in the southwest of the country, has had a population-based cancer registry operating since 1990. Although population-based studies concerning childhood cancer incidence and survival are important to evaluate local health services, studies are rarely available for the region.</p>
+				<p>Childhood cancer (diagnosed between the ages of 0-19 years) includes a variety of malignancies, with incidence varying worldwide by age, gender, ethnicity and geography, a variation which could provide insights into cancer etiology.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B9"><sup>9</sup></xref> This type of cancer is considered rare when compared to cancer in adults, representing approximately 2.5-3% of all types of cancer in Latin America and the Caribbean.<xref ref-type="bibr" rid="B6"><sup>6</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B10"><sup>10</sup></xref>
+				</p>
+				<p>Despite this low incidence, the number of new cases in this age group represents a major public health impact due to the frequently high rates of mortality, with the severe consequences due to treatment and the neoplasms themselves aggravated by the suffering experienced by the family.<xref ref-type="bibr" rid="B11"><sup>11</sup></xref>
+				</p>
+				<p>In Brazil, 32.9% of the population is under 19 years of age<xref ref-type="bibr" rid="B12"><sup>12</sup></xref> and although cancer in this age group is rare, it is estimated that there were 11,530 cases among Brazilian children in 2012. According to a report using 14 of the Brazilian population-based cancer registries for all their years of coverage, the average incidence is 154.3 per million children.<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>
+				</p>
+				<p>Cancer has specific behaviors in this age group, therefore the implementation of monitoring is measure for prevention as well as for knowledge production, providing greater visibility to the issue.</p>
+				<p>It is known that in Brazil there are inequities in access to health services for the treatment of cancer in children, and in this sense, the country has features similar to those found in other developing countries, in which the magnitude of cancer is still poorly known. This situation impedes the planning of health actions and the implementation of strategies for prevention and care in the whole population.<xref ref-type="bibr" rid="B13"><sup>13</sup></xref>
+				</p>
+				<p>Given the special features of childhood cancer, epidemiological studies are of great important. They analyze the distribution of cases in the community and construct indicators and weights to generate greater knowledge of the events, which are essential in identifying the affected population and the demands for care.<xref ref-type="bibr" rid="B14"><sup>14</sup></xref>
+				</p>
+				<p>Scott<xref ref-type="bibr" rid="B15"><sup>15</sup></xref> evaluated the use of geographic information systems (GIS) positively in the creation of a health information system about cancer. Even with the incomplete data that had been recorded in South Africa, the technique had the potential to add value to the information system, contributing knowledge regarding a demand which until then had not been considered.</p>
+				<p>Even in the presence of population-based cancer registries, the collection of information about childhood cancer is often unknown in many low-income and middle-income countries, where data on the incidence of cancer are not collected. Additional data sources might be required, and the resulting statistics must be subjected to meticulous quality control. Regarding the worldwide incidence of childhood cancer, only three publications from the years 1988, 1998, and, more recently, 2017 are available. The distances between these dates highlight the complexity existing in the records of cases of childhood cancer, as they are more sensitive to imprecision or missing information.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>
+				</p>
+				<p>A better understanding of the incidence and spatial patterns of childhood cancer in the local area may help in targeting health services and provide clues for planning in the healthcare system.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B16"><sup>16</sup></xref> Although geographic analysis can be innovative when it comes to information on cancer incidence, it is known that there is a gap in the scientific literature regarding this issue. Therefore, this study analyses spatial patterns of cancer incidence among children (0-14 years) and adolescents (15-19 years) who are residents of Campinas and were diagnosed in the 1996-2005 period. This study is part of a doctoral dissertation defended in 2015 entitled “Overview of cancer among children and adolescents in the perspective of Collective Health”<italic>.</italic><xref ref-type="bibr" rid="B17"><sup>17</sup></xref>
+				</p>
+			</sec>
+			<sec sec-type="materials|methods">
+				<title>MATERIAL AND METHODS</title>
+				<p>A retrospective observational study of cancer among children and adolescents (0-19 years of age) in Campinas, São Paulo, Brazil, diagnosed in the period from 1996-2005 was conducted.</p>
+				<p>Campinas is an industrial city located in the state of São Paulo, Brazil, with approximately 1.1 million inhabitants. About 30% of the population living in Campinas is under the age of 19 years. During the study period there was an increase of 8.34% in the population under 19 years.<xref ref-type="bibr" rid="B12"><sup>12</sup></xref>
+				</p>
+				<p>In 2000, Campinas was divided by the Municipal Health Department into 47 health care unit coverage areas, which are the geographic units used in the spatial analysis. The population under 19 years in these areas ranged from 1,099 to 7,036, with a median of 3,429. </p>
+				<p>The main cancer care for children and adolescents occurs in the High Complexity Care Unit for Pediatric Oncology, and according to an assessment of the population-based cancer registry of Campinas, this unit has an 85% coverage of incident cases in the city for this age group.<xref ref-type="bibr" rid="B18"><sup>18</sup></xref>
+				</p>
+				<p>Although Campinas has a population-based cancer registry, no data were available for the time period considered in this research. Therefore, this study was conducted in the mentioned High Complexity Care Unit in Pediatric Oncology. This study used all data collection steps already validated for population-based cancer registries and the main procedure for gathering data was active notification of cases.</p>
+				<p>The present study was conducted in accordance with Resolution 196/96 of the Brazilian National Health Council and was approved by the Human Research Ethics Committee. The overarching study in which this article was based was approved by the Human Research Ethics Committee of the Boldrini Children’s Center (CEP-Boldrini) (CAAE 0566.0.000.144-11) No. 06/2011, on May 13, 2011.</p>
+				<sec>
+					<title>Case definition</title>
+					<p>Data were retrieved for all children and adolescents residing in Campinas aged 0-19 years who were diagnosed between January 1, 1996 and December 31, 2005. Confirmed diagnosis of cancer was obtained from medical records, using the date of diagnosis of the first primary tumor.</p>
+					<p>To avoid the inclusion of cases not from the population at risk, a data check was performed manually, comparing the home address of cases with the covered geographical area.</p>
+					<p>Cancers were classified according to the International Classification for Childhood Cancer, third edition (ICCC-3).<xref ref-type="bibr" rid="B19"><sup>19</sup></xref> Benign tumors were excluded. By design, just the most common 4 groups were studied: Group I, Leukemias; Group II, Lymphomas and reticuloendothelial neoplasms; Group III, Central nervous system and miscellaneous intracranial and intraspinal neoplasms; and Group IX, Soft tissue and other extraosseous sarcomas. </p>
+				</sec>
+				<sec>
+					<title>Cancer Incidence</title>
+					<p>The person-years for the period under analysis were obtained from population estimates from the Brazilian Institute of Geography and Statistics [<italic>Instituto Brasileiro de Geografia e Estatística</italic>] (IBGE).<xref ref-type="bibr" rid="B12"><sup>12</sup></xref> Average annual crude and standardized incidence rates, calculated per 1,000,000 inhabitants, express the risk of new cases. The population denominators used for calculation of the incidence rates were based on the population census in 2000 and estimated projected numbers for the remaining years.<xref ref-type="bibr" rid="B12"><sup>12</sup></xref> Age-specific incidence rates per million inhabitants were calculated for children and adolescents in the corresponding age group, resident in the city of Campinas.<xref ref-type="bibr" rid="B12"><sup>12</sup></xref> Age-standardized incidence rates (ASIR) were calculated by the direct method, using the World standard population,<xref ref-type="bibr" rid="B20"><sup>20</sup></xref> in order to control for differences that may exist in the age and sex structure between regions and to compare the incidence rates between regions. In other words, considering that <italic>yijk</italic> represents the number of cancer cases (between 1996 and 2005) in health care unit area <italic>i</italic> (<italic>i=</italic>1,...,47), in sex <italic>j</italic> (<italic>j</italic>=1,2) and age group <italic>k</italic> (<italic>k=</italic>1,...,4 respectively for age groups 0-4, 5-9, 10-14 and 15-19 years-old) and <italic>Nijk</italic> the number of individuals at risk in area <italic>i</italic>, sex <italic>j</italic> and age group <italic>k</italic>, the ASIR were estimated by:</p>
+					<p>
+						<disp-formula id="e13">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e13.jpg"/>
+						</disp-formula>
+					</p>
+					<p>Where</p>
+					<p>
+						<disp-formula id="e14">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e14.jpg"/>
+						</disp-formula>
+					</p>
+					<p>represents the number of expected cases for each region <italic>i</italic>, <italic>NPjk</italic> represents the number of individuals in the standard population of sex <italic>j</italic> and age group <italic>k</italic>, and <italic>CIRijk=yijk/ Nijk</italic> represents the crude incidence of region <italic>i</italic>, in sex <italic>j</italic> and age group <italic>k</italic>. The confidence interval was calculated based on the exact method based on the Poisson distribution (appropriate for small numbers).</p>
+				</sec>
+				<sec>
+					<title>Spatial analysis</title>
+					<p>The digital maps of administrative limits were produced by the IBGE. We used the health care unit areas, which correspond to the coverage area of health centers in the city and their respective population.</p>
+					<p>The conventional measure used in disease mapping is the standardized morbidity ratio (SMR) that refers to the incidence in this period. For each area <italic>i</italic>, the SMR is defined as the ratio of observed cases <italic>yi</italic> to expected cases <italic>ei</italic>. The <italic>ei</italic> were calculated based on the indirect standardization was used to control the effect of sex and age.<xref ref-type="bibr" rid="B21"><sup>21</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B22"><sup>22</sup></xref> The expected cases were calculated as follows: considering <italic>i</italic> the health care unit area index, <italic>j</italic> the sex index and <italic>k</italic> the age group index, then <italic>yijk</italic> represents the number of events of sex <italic>j</italic> and age group <italic>k</italic> in the area <italic>i</italic>, and <italic>Nijk</italic> the number of people at risk by sex <italic>j</italic> and age <italic>k</italic> in the area <italic>i</italic>. </p>
+					<p>The overall rate for the city by age group and sex was given by the following expression: </p>
+					<p>
+						<disp-formula id="e15">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e15.jpg"/>
+						</disp-formula>
+					</p>
+					<p>Then the expression:</p>
+					<p>
+						<disp-formula id="e16">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e16.jpg"/>
+						</disp-formula>
+					</p>
+					<p>represents the expected number of events in the area <italic>i</italic>, sex <italic>j</italic> and age group <italic>k</italic>. Therefore, the expected number of events in the area <italic>i</italic>, assuming constant risk within each age and sex class, was given by, </p>
+					<p>
+						<disp-formula id="e17">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e17.jpg"/>
+						</disp-formula>
+					</p>
+					<p>that is, the sum of expected values in the area over age and sex classes. Consequently, the SMR adjusted by age group and sex for each health care unit area <italic>i</italic> (<italic>i</italic>=1,...,47), assuming that the risk is constant in each area, is given by:</p>
+					<p>
+						<disp-formula id="e18">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e18.jpg"/>
+						</disp-formula>
+					</p>
+					<p>In order to control for data heterogeneity and spatial autocorrelation between areas, a spatial Bayesian hierarchical regression model was fitted. The parameters of interest were estimated by the following model:</p>
+					<p>
+						<disp-formula id="e19">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e19.jpg"/>
+						</disp-formula>
+					</p>
+					<p>where</p>
+					<p>
+						<disp-formula id="e20">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e20.jpg"/>
+						</disp-formula>
+					</p>
+					<p>
+						<disp-formula id="e21">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e21.jpg"/>
+						</disp-formula>
+					</p>
+					<p>The inclusion of random effects <italic>Øi</italic> introduces a latent effect into the model to capture the impact of unknown/unobserved confounding area-level factors. These spatially unstructured random effects can help to account for overdispersion (presence of greater variability in the data) in the distribution of childhood cancer incidence counts <italic>yi</italic>. However, this does not allow for explicit spatial dependence between <italic>yi</italic>. This dependence was included by adding a spatially structured random effect <italic>vi</italic>. To allow for spatial dependence, a Conditionally Auto-Regressive (CAR) model<xref ref-type="bibr" rid="B21"><sup>21</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B22"><sup>22</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B23"><sup>23</sup></xref><sup>)</sup> is assumed for <italic>vi</italic>, defined by: </p>
+					<p>
+						<disp-formula id="e22">
+							<graphic xlink:href="1851-8265-scol-14-01-51-e22.jpg"/>
+						</disp-formula>
+					</p>
+					<p>where <italic>wij</italic> are the adjacency weights for the areas. In this study <italic>wij</italic> were taken as simple binary values: <italic>wij</italic>=1 if area <italic>i</italic> has common boundary with area <italic>j</italic> and <italic>wij</italic>=0 otherwise; <italic>σv</italic> was the hyperparameter that controls the strength of local spatial dependence. </p>
+					<p>Uninformative prior distributions were assumed for the model parameters. Parameter was given a Gaussian prior with 0 mean and large variance (1,000) whereas the inverse of <inline-graphic xlink:href="1851-8265-scol-14-01-51-i011.jpg"/> and <inline-graphic xlink:href="1851-8265-scol-14-01-51-i012.jpg"/> priors were assumed to be Gamma distributed (0.5; 0.0005).<xref ref-type="bibr" rid="B24"><sup>24</sup></xref>
+					</p>
+					<p>The relative risk (RR) and the 95% credible intervals were estimated using the mean and the 2.5% and 97.5% empirical quantiles, respectively, of the posterior samples from each parameter of interest. These samples are based on two Markov chains with the Monte Carlo method (MCMC) with 100,000 iterations each and a burn-in period of 10,000. All cut-off points used in the maps correspond to the quartiles of the measurements that we are presenting.</p>
+					<p>The analyses were performed using the following software: SPSS, Geoda, Winbugs (WinBUGS14, Cambridge, UK)<xref ref-type="bibr" rid="B25"><sup>25</sup></xref> and R version 2.14.1 (Project for Statistical Computing),<xref ref-type="bibr" rid="B26"><sup>26</sup></xref> using R2WinBUGS package to connect the last two tools. WinBUGS uses Gibbs sampling, a specific MCMC method, to produce samples from the posterior distribution of each parameter. </p>
+				</sec>
+			</sec>
+			<sec sec-type="results">
+				<title>RESULTS</title>
+				<p>A total of 180 cases were diagnosed, 154 in children and 26 in adolescents. <xref ref-type="table" rid="t2">Table 1</xref> shows the absolute frequency distribution of tumor cases by diagnostic groups as well as the incidence rates per million by age - stratified into two groups, 0-14 and 15-19 years - and diagnostic groups.</p>
+				<p>
+					<table-wrap id="t2">
+						<label>Table 1</label>
+						<caption>
+							<title>Frequency, male to female ratio, and incidence rates per million inhabitants according to cancer diagnostic group and age group in people 0-19 years of age. Campinas, São Paulo, Brazil. 1996-2005.</title>
+						</caption>
+						<graphic xlink:href="1851-8265-scol-14-01-51-gt2.jpg"/>
+						<table-wrap-foot>
+							<fn id="TFN2">
+								<p>Source: Own elaboration based on the High Complexity Care Unit in Pediatric Oncology and the Brazilian Institute of Geography and Statistics [<italic>Instituto Brasileiro de Geografia e Estatística</italic>] (IBGE). ASIR = Age-standardized incidence rates.</p>
+							</fn>
+						</table-wrap-foot>
+					</table-wrap>
+				</p>
+				<p>The most frequent neoplasms were: acute lymphoblastic leukemia (children: 37.7%; adolescents: 15.4%), acute non-lymphoblastic leukemia (children: 13%; adolescents: 23.1%), astrocytomas (children: 11%) and Hodgkin lymphomas (adolescents: 19.2%) (<xref ref-type="table" rid="t1">Table 1</xref>).</p>
+				<p>Among children, the most frequent tumors were in Group I, which accounted for 52% of the overall number of incident neoplasms, followed by Group III (22.7%), and Group II (18.1%). Among adolescents, the diagnostic Group II represented 42.2% of the diagnoses, followed by Group I (38.5%), and Group III (11.5%). Pronounced differences in the male/female ratio were observed for Group II. </p>
+				<p>Overall crude incidence rates (cases per million) was 54.2 [CI95% (46.2-62.1)]; 64.2 in children [CI95% (54.0-74.3)], and 28.2 in adolescents [CI95% (17.3-39.0)]. The overall age-standardized incidence rate (cases per million) in people 0-19 years was 56.5 [CI95% (48.1-64.9)], and ASIR per group were as follows: Group I, 28.8 [CI95% (22.7-34.8)]; Group II, 11.6 [CI95% (7.85-15.2)]; Group III, 11.9 [CI95% (8.08-5.7)] and Group IX, 4.3 [CI95% (1.94-6.74)] (<xref ref-type="table" rid="t1">Table 1</xref>).</p>
+				<p>The geographical pattern of incidence rates was analyzed and higher crude incidence rates were present in some of the southern and western health care unit areas. The age-standardized incidence rates of cancer among children and adolescents for the period, according to health care unit area, were also calculated. An accentuated geographic pattern was found, with the lowest incidence rates in the north and east of Campinas. <xref ref-type="fig" rid="f4">Figure 1</xref> shows the map of SMR. The highest SMR are concentrated in the southwest and southeast regions of the municipality.</p>
+				<p>
+					<fig id="f4">
+						<label>Figure 1</label>
+						<caption>
+							<title>Standardized morbidity ratio (SMR) for cancer among people 0-19 years of age, by health care unit area. Campinas, São Paulo, Brazil, 1996-2005</title>
+						</caption>
+						<graphic xlink:href="1851-8265-scol-14-01-51-gf4.jpg"/>
+						<attrib>Source: Own elaboration based on the High Complexity Care Unit in Pediatric Oncology and the Brazilian Institute of Geography and Statistics [<italic>Instituto Brasileiro de Geografia e Estatística</italic>] (IBGE)</attrib>
+					</fig>
+				</p>
+				<p>Considering the model described above, there is an accentuated geographic pattern, with a lower distribution in the north area of city. The relative risks (RR) were not statistically significant among the health care unit areas. <xref ref-type="fig" rid="f5">Figure 2</xref> and <xref ref-type="fig" rid="f6">Figure 3</xref> show the modeled RR for childhood cancer and the 95% credible intervals. Although some health care unit areas to the south and west present higher crude incidence rates, no statistically significant differences in the RR were observed. </p>
+				<p>
+					<fig id="f5">
+						<label>Figure 2</label>
+						<caption>
+							<title>Estimated relative risk of cancer incidence among people 0-19 years of age according to health care unit area. Campinas, São Paulo, Brazil, 1996-2005</title>
+						</caption>
+						<graphic xlink:href="1851-8265-scol-14-01-51-gf5.jpg"/>
+						<attrib>Source: Own elaboration based on the High Complexity Care Unit in Pediatric Oncology and the Brazilian Institute of Geography and Statistics [<italic>Instituto Brasileiro de Geografia e Estatística</italic>] (IBGE)</attrib>
+					</fig>
+				</p>
+				<p>
+					<fig id="f6">
+						<label>Figure 3</label>
+						<caption>
+							<title>Estimated relative risk and 95% credible intervals of cancer incidence among people 0-19 years of age according to health care unit area. Campinas, São Paulo, Brazil, 1996-2005</title>
+						</caption>
+						<graphic xlink:href="1851-8265-scol-14-01-51-gf6.jpg"/>
+						<attrib>Source: Own elaboration based on the High Complexity Care Unit in Pediatric Oncology and the Brazilian Institute of Geography and Statistics [<italic>Instituto Brasileiro de Geografia e Estatística</italic>] (IBGE)</attrib>
+					</fig>
+				</p>
+			</sec>
+			<sec sec-type="discussion">
+				<title>DISCUSSION</title>
+				<p>This study analyses the childhood cancer in Campinas and uses spatial analysis to examine the incidence pattern and distribution in the city. The most frequent childhood cancer adjusted by age was Group I (Leukemia, 28.8 per million), followed by Group III (Central nervous system and miscellaneous intracranial and intraspinal neoplasm, 11.9 per million). </p>
+				<p>Considering that characteristics, frequency and cancer type distribution in children and adolescents are unique and different from those observed at any other age-group, it has been recommended that epidemiological studies of childhood cancer be performed separately from other age groups.<xref ref-type="bibr" rid="B8"><sup>8</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B27"><sup>27</sup></xref>
+				</p>
+				<p>In Campinas, similarly to results from previous reports using European registries, the most frequent childhood cancer is Group I, representing age-standardized incidence rates lower than those of the majority of European countries but similar to Portugal (28 per million), Poland (29.9 per million) and Romania (28.3 per million).<xref ref-type="bibr" rid="B28"><sup>28</sup></xref> It has been suggested that such rates among childhood cancers might reflect the socioeconomic development of the society, with the more affluent societies exhibiting higher rates.<xref ref-type="bibr" rid="B29"><sup>29</sup></xref>
+				</p>
+				<p>In this regard, we found that in Campinas the highest values of SMR are concentrated in the southwest and southeast regions of the municipality, corresponding to the major areas of social inequalities in this city; however, this may be related to unobserved variables, and future research is needed. The problem of childhood cancer cannot be evaluated separately from the level of development and health conditions of each region. Population growth, poverty, poor hygiene, lack of education, and a multitude health problems impede the development of pediatric oncology and the success of the management of childhood cancer in developing countries.<xref ref-type="bibr" rid="B29"><sup>29</sup></xref>
+				</p>
+				<p>In addition, the distribution of cases by sex, age and the four most common groups of disease are similar to those found in other Brazilian studies based on 14 Brazilian population-based cancer registries.<xref ref-type="bibr" rid="B6"><sup>6</sup></xref> Comparing the present data analysis with previous Brazilian publications on childhood cancer, tumors of the central nervous system were also the second common childhood tumor observed.<xref ref-type="bibr" rid="B6"><sup>6</sup></xref>
+				</p>
+				<p>Leukemias are the most common cancer in children worldwide and have the largest impact on total cancer incidence. Comparatively, the incidence that most resembled our study was that found in North Africa (28.2 per million).<xref ref-type="bibr" rid="B7"><sup>7</sup></xref> Acute lymphoblastic leukemia, Acute non-lymphoblastic leukemia, Astrocytomas, and Hodgkin lymphomas were the most frequent diagnoses in Campinas, both in children and adolescents, facts already reported in the literature.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B30"><sup>30</sup></xref>
+				</p>
+				<p>Regarding the records found for South America, only Group II incidence was similar to the findings in the present study (11.6 per million); for the other three groups studied, the incidence was higher in the other countries of South America.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref>
+				</p>
+				<p>Compared to European countries, the largest differences in incidences were observed for Group III and Group IX. In European countries the standardized incidence rates for Group III (29.5 per million) and for Group IX (9.4 per million) are more than twice as great as those found in Campinas (Group II incidence, 11.9 per million and Group IX incidence, 4.3 per million). However, in relation to Group IX, the incidence resembles those found in South Africa and Native Americans in the US.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B28"><sup>28</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B31"><sup>31</sup></xref>
+				</p>
+				<p>These differences may be explained by the type of tumor (solid) affecting mainly adolescents, who could have been treated elsewhere or regarded as young adult cases and not referred to the High Complexity Care Unit in Pediatric Oncology.</p>
+				<p>Although incidence rates in the four diagnostic groups studied differ from the observations of the population-based cancer registries from developed countries, they are similar to those found in the literature for developing countries, including Brazil.<xref ref-type="bibr" rid="B7"><sup>7</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B32"><sup>32</sup></xref><sup>,</sup><xref ref-type="bibr" rid="B33"><sup>33</sup></xref>
+				</p>
+				<p>A limitation of the study results from the data source, as records were obtained from only one childhood oncology service. Although the population-based cancer registry affirms that there was 85% coverage of the cases in city residents, it is possible that the profile of patients not included in the analysis differs from that seen in our results. </p>
+				<p>The creation of efficient monitoring systems for cancer, in particular for rare cases of childhood cancer, is necessary across healthcare networks. In addition, their creation would greatly potentiate the value of spatial analysis by permitting more precise results. Future steps should investigate the relationship between geography and childhood cancer incidence rates for a wider range of health measures and outcomes.<xref ref-type="bibr" rid="B16"><sup>16</sup></xref>
+				</p>
+				<p>In conclusion, our results are in agreement with previous reports from other cancer registries. The present application to cancer incidence in a Brazilian region produced evidence of similar distribution of cancer among children and adolescents. This study of the cancer incidence rates and the analysis of the SMR spatial patterns can be paramount in the definition of intervention programs in the region. Therefore, it can help in the development of health care programs for the reduction of morbidity and mortality in childhood cancer and, concomitantly, in the planning of interventions as well as in the structuration of the health care network.</p>
+			</sec>
+		</body>
+		<back>
+			<ack>
+				<title>ACKNOWLEDGEMENTS</title>
+				<p>We thank the Brazilian Coordenação de Aperfeiçoamento de Pessoal de Nivel Superior (CAPES) for the financial support (No. 99999.007495/2014-05) as well as the important contribution of researchers from the Universideade do Porto and the population-based cancer registry of Campinas. </p>
+			</ack>
+		</back>
+	</sub-article>
+</article>

--- a/opac_proc/tests/fixtures/article.json
+++ b/opac_proc/tests/fixtures/article.json
@@ -1,0 +1,6028 @@
+{
+    "title": {
+        "v68": [
+            {
+                "_": "scol"
+            }
+        ],
+        "v943": [
+            {
+                "_": "20170718"
+            }
+        ],
+        "v942": [
+            {
+                "_": "20110715"
+            }
+        ],
+        "v992": [
+            {
+                "_": "spa"
+            }
+        ],
+        "created_at": "2011-07-15",
+        "v320": [
+            {
+                "_": "Buenos Aires"
+            }
+        ],
+        "v450": [
+            {
+                "_": "PASCAL - PROGRAMME APPLIQU\u00c9 \u00c0 LA S\u00c9LECTION ET \u00c0 LA COMPILATION AUTOMATIQUE DE LA LITT\u00c9RATURE\tWEB OF KNOWLEDGE"
+            },
+            {
+                "_": "SSCI - SOCIAL SCIENCES CITATION INDEX"
+            },
+            {
+                "_": "SCOPUS"
+            },
+            {
+                "_": "DOAJ - DIRECTORY OF OPEN ACCESS JOURNALS"
+            },
+            {
+                "_": "DIALNET - PORTAL DE DIFUSI\u00d3N DE LA PRODUCCI\u00d3N CIENT\u00cdFICA HISPANA"
+            },
+            {
+                "_": "REDALYC - RED DE REVISTAS CIENT\u00cdFICAS DE AM\u00c9RICA LATINA Y EL CARIBE, ESPA\u00d1A Y PORTUGAL"
+            },
+            {
+                "_": "HAPI - HISPANIC AMERICAN PERIODICAL INDEX"
+            },
+            {
+                "_": "HINARI - ACCESS TO RESEARCH IN HEALTH POGRAMME"
+            },
+            {
+                "_": "FREE MEDICAL JOURNALS"
+            }
+        ],
+        "v6": [
+            {
+                "_": "c"
+            }
+        ],
+        "v140": [
+            {
+                "_": "Universidad Nacional de Lan\u00fas"
+            }
+        ],
+        "v935": [
+            {
+                "_": "1669-2381"
+            }
+        ],
+        "v941": [
+            {
+                "_": "20160415"
+            }
+        ],
+        "issns": [
+            "1669-2381",
+            "1851-8265"
+        ],
+        "v67": [
+            {
+                "_": "na"
+            }
+        ],
+        "v880": [
+            {
+                "_": "1851-8265"
+            }
+        ],
+        "v350": [
+            {
+                "_": "en"
+            },
+            {
+                "_": "pt"
+            },
+            {
+                "_": "es"
+            }
+        ],
+        "v301": [
+            {
+                "_": "2005"
+            }
+        ],
+        "v380": [
+            {
+                "_": "T"
+            }
+        ],
+        "v854": [
+            {
+                "_": "Health Policy & Services"
+            }
+        ],
+        "v440": [
+            {
+                "_": "SA\u00daDE COLETIVA"
+            },
+            {
+                "_": "EPIDEMIOLOGIA"
+            },
+            {
+                "_": "SA\u00daDE P\u00daBLICA"
+            }
+        ],
+        "v100": [
+            {
+                "_": "Salud Colectiva"
+            }
+        ],
+        "collection": "spa",
+        "v66": [
+            {
+                "_": "art"
+            }
+        ],
+        "updated_date": "2016-04-15",
+        "v303": [
+            {
+                "_": "1"
+            }
+        ],
+        "v930": [
+            {
+                "_": "scol"
+            }
+        ],
+        "v150": [
+            {
+                "_": "Salud Colectiva"
+            }
+        ],
+        "v950": [
+            {
+                "_": "sonia.reis"
+            }
+        ],
+        "v540": [
+            {
+                "l": "en",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>."
+            },
+            {
+                "l": "es",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>."
+            },
+            {
+                "l": "pt",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>."
+            }
+        ],
+        "v117": [
+            {
+                "_": "other"
+            }
+        ],
+        "code": "1851-8265",
+        "v310": [
+            {
+                "_": "AR"
+            }
+        ],
+        "v63": [
+            {
+                "_": "29 de Septiembre, 3901, Lan\u00fas, Buenos Aires, AR, B1826GLC, 54 11 6322-9200"
+            }
+        ],
+        "v62": [
+            {
+                "_": "Universidad Nacional de Lan\u00fas"
+            }
+        ],
+        "v51": [
+            {
+                "a": "20110701",
+                "b": "C",
+                "_": ""
+            }
+        ],
+        "v64": [
+            {
+                "_": "revistasaludcolectiva@yahoo.com.ar"
+            }
+        ],
+        "v35": [
+            {
+                "_": "ONLIN"
+            }
+        ],
+        "v490": [
+            {
+                "_": "Lan\u00fas"
+            }
+        ],
+        "processing_date": "2016-04-15",
+        "updated_at": "2017-08-10",
+        "v151": [
+            {
+                "_": "Salud Colectiva"
+            }
+        ],
+        "v302": [
+            {
+                "_": "1"
+            }
+        ],
+        "v951": [
+            {
+                "_": "sonia.reis"
+            }
+        ],
+        "v541": [
+            {
+                "_": "BY-NC/4.0"
+            }
+        ],
+        "v50": [
+            {
+                "_": "C"
+            }
+        ],
+        "v421": [
+            {
+                "_": "Salud Colect"
+            }
+        ],
+        "v441": [
+            {
+                "_": "Health Sciences"
+            }
+        ],
+        "v400": [
+            {
+                "_": "1851-8265"
+            }
+        ],
+        "v5": [
+            {
+                "_": "S"
+            }
+        ],
+        "v940": [
+            {
+                "_": "20110715"
+            }
+        ],
+        "v480": [
+            {
+                "_": "Universidad Nacional de Lan\u00fas"
+            }
+        ],
+        "v330": [
+            {
+                "_": "CT"
+            }
+        ],
+        "v901": [
+            {
+                "l": "es",
+                "_": "Difundir art\u00edculos originales e in\u00e9ditos en espa\u00f1ol que contribuyan al estudio del proceso salud-enfermedad-atenci\u00f3n-cuidado (PSEAC). Su prop\u00f3sito es generar un espacio editorial para el pensamiento cr\u00edtico en el campo de lo social, sobre la base del libre acceso (Open Access), la calidad cient\u00edfica, el rigor metodol\u00f3gico y la apertura multidisclipinaria."
+            },
+            {
+                "l": "pt",
+                "_": "Difundir artigos originais e in\u00e9ditos em espanhol  que contribuam para o estudo do processo sa\u00fade-doen\u00e7a-aten\u00e7\u00e3o-cuidado (PSEAC). Seu prop\u00f3sito \u00e9 propiciar um espa\u00e7o editorial em acesso aberto (Open Acess), para o pensamento cr\u00edtico sobre o social, a qualidade cient\u00edfica, o rigor metodol\u00f3gico e a abertura multidisciplinar."
+            },
+            {
+                "l": "en",
+                "_": "To disseminate original and unpublished articles in Spanish which contribute to the study of the health-disease-care process (HDCP). The journal seeks to create an editorial framework for critical thought about the social realm, based upon the Open Access model, a commitment to scientific and methodological rigor, and openness to multidisciplinary study."
+            }
+        ],
+        "v85": [
+            {
+                "_": "decs"
+            }
+        ],
+        "v435": [
+            {
+                "_": "1851-8265",
+                "t": "ONLIN"
+            },
+            {
+                "_": "1669-2381",
+                "t": "PRINT"
+            }
+        ],
+        "v10": [
+            {
+                "_": "br1.1"
+            }
+        ]
+    },
+    "fulltexts": {
+        "html": {
+            "en": "http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S1851-82652018000100051&tlng=en",
+            "es": "http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S1851-82652018000100051&tlng=es"
+        }
+    },
+    "created_at": "2018-07-12",
+    "doi": "10.18294/SC.2018.1200",
+    "collection": "spa",
+    "article": {
+        "v702": [
+            {
+                "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+            }
+        ],
+        "v992": [
+            {
+                "_": "spa"
+            }
+        ],
+        "v705": [
+            {
+                "_": "S"
+            }
+        ],
+        "v49": [
+            {
+                "_": "SCOL-x5c5"
+            }
+        ],
+        "v35": [
+            {
+                "_": "1851-8265"
+            }
+        ],
+        "v72": [
+            {
+                "_": "33"
+            }
+        ],
+        "v936": [
+            {
+                "y": "2018",
+                "i": "1851-8265",
+                "o": "1",
+                "_": ""
+            }
+        ],
+        "v14": [
+            {
+                "l": "63",
+                "f": "51",
+                "_": ""
+            }
+        ],
+        "v435": [
+            {
+                "_": "1669-2381",
+                "t": "ppub"
+            },
+            {
+                "_": "1851-8265",
+                "t": "epub"
+            }
+        ],
+        "processing_date": "2018-07-12",
+        "v83": [
+            {
+                "a": "RESUMEN Analizamos los patrones espaciales y las incidencias de c\u00e1ncer en ni\u00f1os, ni\u00f1as y adolescentes de 0 a 19 a\u00f1os de edad residentes en la ciudad de Campinas, al sureste de Brasil, diagnosticados entre 1996 y 2005. Se clasificaron los c\u00e1nceres seg\u00fan los grupos de la tercera revisi\u00f3n de la International Classification of Childhood Cancer (ICCC-3). Se incluyeron los cuatro grupos m\u00e1s comunes: leucemias, linfomas, y las neoplasias del sistema nervioso central y de tejidos blandos. Se calcularon tasas de incidencia estandarizadas por edad utilizando la poblaci\u00f3n mundial est\u00e1ndar. Se ajust\u00f3 un modelo espacial de regresi\u00f3n jer\u00e1rquica de Bayes (controlando por la heterogeneidad de los datos y la autocorrelaci\u00f3n espacial), que asume que el n\u00famero de casos sigue una distribuci\u00f3n de Poisson. Se diagnostic\u00f3 un total de 180 casos durante el periodo de estudio. La tasa de incidencia bruta para las edades 0-19 a\u00f1os fue de 54,2 por mill\u00f3n y la tasa de incidencia estandarizada por edad fue de 56,5 por mill\u00f3n. Si bien algunas regiones presentan tasas de incidencia m\u00e1s altas al considerar la heterogeneidad y la autocorrelaci\u00f3n, no se observaron diferencias estad\u00edsticamente significativas en los riesgos relativos.",
+                "l": "es",
+                "_": ""
+            },
+            {
+                "a": "ABSTRACT This article analyzes cancer incidence and spatial patterns in children and adolescents (0-19 years of age) residing in the city of Campinas in Southeastern Brazil who were diagnosed from 1996-2005. Cancers were classified according to the Third International Classification of Childhood Cancer (ICCC-3) Groups. The four most common groups were studied: leukemias, lymphomas, and central nervous system and soft tissue neoplasms. Age-standardized incidence rates were calculated using the world standard population. A spatial Bayesian hierarchical regression model (controlling for data heterogeneity and spatial autocorrelation) was fitted, assuming that the number of cancer cases follows a Poisson distribution. A total of 180 cases were diagnosed during the study period. Overall, the crude incidence rate was 54.2 per million and the age-standardized incidence rate was 56.5 per million. Although some regions present higher incidence rates, considering the spatial heterogeneity and the spatial autocorrelation, no statistically significant differences in the relative risks were observed.",
+                "l": "en",
+                "_": ""
+            }
+        ],
+        "v120": [
+            {
+                "_": "XML_1.1"
+            }
+        ],
+        "v62": [
+            {
+                "_": "Universidad Nacional de Lan\u00fas"
+            }
+        ],
+        "v708": [
+            {
+                "_": "1"
+            }
+        ],
+        "v31": [
+            {
+                "_": "14"
+            }
+        ],
+        "v65": [
+            {
+                "_": "20180300"
+            }
+        ],
+        "v42": [
+            {
+                "_": "1"
+            }
+        ],
+        "v880": [
+            {
+                "_": "S1851-82652018000100051"
+            }
+        ],
+        "v4": [
+            {
+                "_": "v14n1"
+            }
+        ],
+        "v71": [
+            {
+                "_": "oa"
+            }
+        ],
+        "v112": [
+            {
+                "_": "20161031"
+            }
+        ],
+        "v70": [
+            {
+                "p": "Brazil",
+                "c": "Chapec\u00f3",
+                "e": "jane.friestino@uffs.edu.br",
+                "_": "Universidade Federal da Fronteira Sul",
+                "l": "1",
+                "i": "aff1"
+            },
+            {
+                "p": "Portugal",
+                "e": "dvmendon@icbas.up.pt",
+                "_": "Universidade do Porto",
+                "l": "2",
+                "i": "aff2",
+                "1": "Instituto de Ci\u00eancias Biom\u00e9dicas Abel Salazar"
+            },
+            {
+                "p": "Portugal",
+                "e": "pnoliveira@icbas.up.pt",
+                "_": "Universidade do Porto",
+                "l": "3",
+                "i": "aff3",
+                "1": "Instituto de Ci\u00eancias Biom\u00e9dicas Abel Salazar"
+            },
+            {
+                "p": "Portugal",
+                "e": "carlaoliver@gmail.com",
+                "_": "Universidade do Porto",
+                "l": "4",
+                "i": "aff4",
+                "2": "Instituto de Engenharia Biom\u00e9dica",
+                "1": "Instituto de Investiga\u00e7\u00e3o e Inova\u00e7\u00e3o em Sa\u00fade (i3s)"
+            },
+            {
+                "p": "Brazil",
+                "l": "5",
+                "i": "aff5",
+                "e": "djalmore@unicamp.br",
+                "_": "Universidade Estadual de Campinas"
+            }
+        ],
+        "v38": [
+            {
+                "_": "TAB"
+            },
+            {
+                "_": "GRA"
+            }
+        ],
+        "v40": [
+            {
+                "_": "es"
+            }
+        ],
+        "v709": [
+            {
+                "_": "article"
+            }
+        ],
+        "v237": [
+            {
+                "_": "10.18294/sc.2018.1200"
+            }
+        ],
+        "v999": [
+            {
+                "_": "../bases-work/scol/scol"
+            }
+        ],
+        "v421": [
+            {
+                "_": "Salud Colect"
+            }
+        ],
+        "v100": [
+            {
+                "_": "Salud Colectiva"
+            }
+        ],
+        "collection": "spa",
+        "v882": [
+            {
+                "v": "14",
+                "n": "1",
+                "_": ""
+            }
+        ],
+        "v2": [
+            {
+                "_": "S1851-8265(18)01400100051"
+            }
+        ],
+        "v601": [
+            {
+                "_": "en"
+            }
+        ],
+        "v121": [
+            {
+                "_": "00051"
+            }
+        ],
+        "v701": [
+            {
+                "_": "1"
+            }
+        ],
+        "v91": [
+            {
+                "_": "20180712"
+            }
+        ],
+        "v85": [
+            {
+                "l": "es",
+                "k": "An\u00e1lisis Espacial",
+                "_": ""
+            },
+            {
+                "l": "es",
+                "k": "Neoplasias",
+                "_": ""
+            },
+            {
+                "l": "es",
+                "k": "Salud Infantil",
+                "_": ""
+            },
+            {
+                "l": "es",
+                "k": "Salud del Adolescente",
+                "_": ""
+            },
+            {
+                "l": "es",
+                "k": "Geograf\u00eda M\u00e9dica",
+                "_": ""
+            },
+            {
+                "l": "es",
+                "k": "Brasil",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Spatial Analysis",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Neoplasms",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Child Health",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Adolescent Health",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Medical Geography",
+                "_": ""
+            },
+            {
+                "l": "en",
+                "k": "Brazil",
+                "_": ""
+            }
+        ],
+        "v30": [
+            {
+                "_": "Salud Colectiva"
+            }
+        ],
+        "v706": [
+            {
+                "_": "h"
+            }
+        ],
+        "v700": [
+            {
+                "_": "2"
+            }
+        ],
+        "v240": [
+            {
+                "p": "BR",
+                "i": "aff5",
+                "_": "Universidade Estadual de Campinas"
+            },
+            {
+                "p": "PT",
+                "c": "Porto",
+                "i": "aff4",
+                "_": "Universidade do Porto"
+            },
+            {
+                "p": "PT",
+                "c": "Porto",
+                "i": "aff3",
+                "_": "Universidade do Porto"
+            },
+            {
+                "p": "PT",
+                "c": "Porto",
+                "i": "aff2",
+                "_": "Universidade do Porto"
+            },
+            {
+                "i": "aff1",
+                "p": "BR",
+                "c": "Chapec\u00f3",
+                "s": "Santa Catarina",
+                "_": "Universidade Federal da Fronteira Sul"
+            }
+        ],
+        "v32": [
+            {
+                "_": "1"
+            }
+        ],
+        "v10": [
+            {
+                "r": "ND",
+                "n": "Jane Kelly",
+                "_": "",
+                "k": "0000-0002-5432-9560",
+                "s": "Oliveira Friestino",
+                "1": "aff1"
+            },
+            {
+                "r": "ND",
+                "n": "Denisa",
+                "_": "",
+                "k": "0000-0003-4835-8944",
+                "s": "Mendon\u00e7a",
+                "1": "aff2"
+            },
+            {
+                "r": "ND",
+                "n": "Pedro",
+                "_": "",
+                "k": "0000-0002-2470-0795",
+                "s": "Oliveira",
+                "1": "aff3"
+            },
+            {
+                "r": "ND",
+                "n": "Carla M",
+                "_": "",
+                "k": "0000-0002-4594-1723",
+                "s": "Oliveira",
+                "1": "aff4"
+            },
+            {
+                "r": "ND",
+                "n": "Djalma",
+                "_": "",
+                "k": "0000-0002-7943-0868",
+                "s": "de Carvalho Moreira Filho",
+                "1": "aff5"
+            }
+        ],
+        "v114": [
+            {
+                "_": "20170828"
+            }
+        ],
+        "v12": [
+            {
+                "l": "es",
+                "_": "C\u00e1ncer infantil: incidencia y patrones espaciales en la ciudad de Campinas, Brasil, 1996-2005"
+            },
+            {
+                "l": "en",
+                "_": "Childhood cancer: incidence and spatial patterns in the city of Campinas, Brazil, 1996-2005"
+            }
+        ],
+        "code": "S1851-82652018000100051"
+    },
+    "publication_year": "2018",
+    "processing_date": "2018-07-12",
+    "document_type": "research-article",
+    "sent_wos": "False",
+    "validated_wos": "False",
+    "code_title": [
+        "1669-2381",
+        "1851-8265"
+    ],
+    "applicable": "True",
+    "version": "xml",
+    "validated_scielo": "False",
+    "publication_date": "2018-03",
+    "citations": [
+        {
+            "v71": [
+                {
+                    "_": "legal-doc"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "1990"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v11": [
+                {
+                    "_": "Brasil"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Di\u00e1rio Oficial da Rep\u00fablica Federativa do Brasil"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19900000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v37": [
+                {
+                    "_": "https://tinyurl.com/d73vyv"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "5"
+                }
+            ],
+            "v61": [
+                {
+                    "_": "Disponible en: https://tinyurl.com/d73vyv"
+                }
+            ],
+            "v109": [
+                {
+                    "_": "2 May 2017"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100001"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Lei 8080, de 19 de setembro de 1990. Disp\u00f5e sobre as condi\u00e7\u00f5es para a promo\u00e7\u00e3o, prote\u00e7\u00e3o e recupera\u00e7\u00e3o da sa\u00fade, a organiza\u00e7\u00e3o e o funcionamento dos servi\u00e7os correspondentes e d\u00e1 outras provid\u00eancias"
+                }
+            ],
+            "code": "S1851-8265201800010005100001"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2014"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "65",
+                    "f": "57",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "57-65"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Salud Colectiva"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "2"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "2"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "10"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20140000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "6"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100002"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "ED",
+                    "r": "ND",
+                    "s": "Nunes",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Collective health paradigms: a brief reflection"
+                }
+            ],
+            "code": "S1851-8265201800010005100002"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "S\u00e3o Paulo"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "1991"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "J",
+                    "r": "ND",
+                    "s": "Breilh",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "Epidemiologia: economia, pol\u00edtica e sa\u00fade"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "Unesp-Hucitec"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19910000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "7"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100003"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100003"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2016"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "879",
+                    "f": "869",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "869-79"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Sa\u00fade e Sociedade"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "25"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20160000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "8"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100004"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "RB",
+                    "r": "ND",
+                    "s": "Guimar\u00e3es",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Geografia e sa\u00fade coletiva no Brasil"
+                }
+            ],
+            "code": "S1851-8265201800010005100004"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Rio de Janeiro"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2008"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "C",
+                    "r": "ND",
+                    "s": "Barcellos",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "5"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "A Geografia e o Contexto dos Problemas de Sa\u00fade"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "5"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "Abrasco"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20080000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "9"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100005"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100005"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2010"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "720",
+                    "f": "715",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "715-20"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "International Journal of Cancer"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "6"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "6"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "126"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20100000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "10"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100006"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "B",
+                    "r": "ND",
+                    "s": "De Camargo",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "De Oliveira Santos",
+                    "_": ""
+                },
+                {
+                    "n": "MS",
+                    "r": "ND",
+                    "s": "Rebelo",
+                    "_": ""
+                },
+                {
+                    "n": "R",
+                    "r": "ND",
+                    "s": "De Souza Reis",
+                    "_": ""
+                },
+                {
+                    "n": "S",
+                    "r": "ND",
+                    "s": "Ferman",
+                    "_": ""
+                },
+                {
+                    "n": "CP",
+                    "r": "ND",
+                    "s": "Noronha",
+                    "_": ""
+                },
+                {
+                    "n": "MS",
+                    "r": "ND",
+                    "s": "Pombo-de-Oliveira",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Cancer incidence among children and adolescents in Brazil: first report of 14 population-based cancer registries"
+                }
+            ],
+            "code": "S1851-8265201800010005100006"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2017"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v11": [
+                {
+                    "_": "IICC-3 contributors"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "731",
+                    "f": "719",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "719-31"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "The Lancet Oncology"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "7"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "7"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "6"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "18"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20170000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "11"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100007"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "Colombet",
+                    "_": ""
+                },
+                {
+                    "n": "LAG",
+                    "r": "ND",
+                    "s": "Ries",
+                    "_": ""
+                },
+                {
+                    "n": "F",
+                    "r": "ND",
+                    "s": "Moreno",
+                    "_": ""
+                },
+                {
+                    "n": "A",
+                    "r": "ND",
+                    "s": "Dolya",
+                    "_": ""
+                },
+                {
+                    "n": "F",
+                    "r": "ND",
+                    "s": "Bray",
+                    "_": ""
+                },
+                {
+                    "n": "P",
+                    "r": "ND",
+                    "s": "Hesseling",
+                    "_": ""
+                },
+                {
+                    "n": "HY",
+                    "r": "ND",
+                    "s": "Shin",
+                    "_": ""
+                },
+                {
+                    "n": "CA",
+                    "r": "ND",
+                    "s": "Stiller",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "International incidence of childhood cancer, 2001-10: a population-based registry study"
+                }
+            ],
+            "code": "S1851-8265201800010005100007"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2013"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "e116",
+                    "f": "e104",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "e104-16"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "The Lancet Oncology"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "8"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "8"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "14"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20130000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "12"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100008"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "I",
+                    "r": "ND",
+                    "s": "Magrath",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                },
+                {
+                    "n": "S",
+                    "r": "ND",
+                    "s": "Epelman",
+                    "_": ""
+                },
+                {
+                    "n": "RC",
+                    "r": "ND",
+                    "s": "Ribeiro",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "Harif",
+                    "_": ""
+                },
+                {
+                    "n": "CK",
+                    "r": "ND",
+                    "s": "Li",
+                    "_": ""
+                },
+                {
+                    "n": "R",
+                    "r": "ND",
+                    "s": "Kebudi",
+                    "_": ""
+                },
+                {
+                    "n": "SD",
+                    "r": "ND",
+                    "s": "Macfarlane",
+                    "_": ""
+                },
+                {
+                    "n": "SC",
+                    "r": "ND",
+                    "s": "Howard",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Paediatric cancer in low-income and middle-income countries"
+                }
+            ],
+            "code": "S1851-8265201800010005100008"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Lyon"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2014"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "D",
+                    "r": "ND",
+                    "s": "Forman",
+                    "_": ""
+                },
+                {
+                    "n": "F",
+                    "r": "ND",
+                    "s": "Bray",
+                    "_": ""
+                },
+                {
+                    "n": "DH",
+                    "r": "ND",
+                    "s": "Brewster",
+                    "_": ""
+                },
+                {
+                    "n": "C",
+                    "r": "ND",
+                    "s": "Gombe Mbalawa",
+                    "_": ""
+                },
+                {
+                    "n": "B",
+                    "r": "ND",
+                    "s": "Kohler",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "Pi\u00f1eros",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                },
+                {
+                    "n": "R",
+                    "r": "ND",
+                    "s": "Swaminathan",
+                    "_": ""
+                },
+                {
+                    "n": "J",
+                    "r": "ND",
+                    "s": "Ferlay",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "9"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "Cancer incidence in five continents Vol-X"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "9"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "International Agency for Research on Cancer"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20140000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v37": [
+                {
+                    "_": "https://tinyurl.com/y8z9w5rk"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "13"
+                }
+            ],
+            "v61": [
+                {
+                    "_": "Disponible en: https://tinyurl.com/y8z9w5rk"
+                }
+            ],
+            "v109": [
+                {
+                    "_": "12 oct 2016"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100009"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100009"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Lyon"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "1998"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "International Incidence of Childhood Cancer"
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "DM",
+                    "r": "ND",
+                    "s": "Parkin",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Kram\u00e1rov\u00e1",
+                    "_": ""
+                },
+                {
+                    "n": "GJ",
+                    "r": "ND",
+                    "s": "Draper",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Masuyer",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "10"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "10"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "IARC Scientific Publication"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "114"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19980000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "14"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100010"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100010"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2012"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "791",
+                    "f": "784",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "784-91"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Ci\u00eancia, Cuidado e Sa\u00fade"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "11"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "11"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "11"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20120000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "15"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100011"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "RP",
+                    "r": "ND",
+                    "s": "Teixeira",
+                    "_": ""
+                },
+                {
+                    "n": "WS",
+                    "r": "ND",
+                    "s": "Ramalho",
+                    "_": ""
+                },
+                {
+                    "n": "ICF",
+                    "r": "ND",
+                    "s": "Fernandes",
+                    "_": ""
+                },
+                {
+                    "n": "AKM",
+                    "r": "ND",
+                    "s": "Salge",
+                    "_": ""
+                },
+                {
+                    "n": "MA",
+                    "r": "ND",
+                    "s": "Barbosa",
+                    "_": ""
+                },
+                {
+                    "n": "KM",
+                    "r": "ND",
+                    "s": "Siqueira",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "A Fam\u00edlia da crian\u00e7a com c\u00e2ncer: percep\u00e7\u00f5es de profissionais de enfermagem atuantes em oncologia pedi\u00e1trica"
+                }
+            ],
+            "code": "S1851-8265201800010005100011"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Brasil"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2010"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v109": [
+                {
+                    "_": "02 May 2017"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "12"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "Infogr\u00e1ficos"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "12"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "IBGE"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20100000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v37": [
+                {
+                    "_": "https://tinyurl.com/ybqtotu2"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "16"
+                }
+            ],
+            "v61": [
+                {
+                    "_": "Disponible en: https://tinyurl.com/ybqtotu2"
+                }
+            ],
+            "v17": [
+                {
+                    "_": "Instituto Brasileiro de Geografia e Estat\u00edstica"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100012"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100012"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2011"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v514": [
+                {
+                    "l": "1720",
+                    "f": "1711",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "1711-20"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Cadernos de Sa\u00fade P\u00fablica"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "13"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "13"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "27"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20110000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "17"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100013"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "MF",
+                    "r": "ND",
+                    "s": "Grabois",
+                    "_": ""
+                },
+                {
+                    "n": "EXG",
+                    "r": "ND",
+                    "s": "Oliveira",
+                    "_": ""
+                },
+                {
+                    "n": "MS",
+                    "r": "ND",
+                    "s": "Carvalho",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Childhood cancer and pediatric oncologic care in Brazil: access and equity"
+                }
+            ],
+            "code": "S1851-8265201800010005100013"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2010"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "83",
+                    "f": "71",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "71-83"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Revista Brasileira de Cancerologia"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "14"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "14"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "56"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20100000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "18"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100014"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "CF",
+                    "r": "ND",
+                    "s": "Mutti",
+                    "_": ""
+                },
+                {
+                    "n": "CC",
+                    "r": "ND",
+                    "s": "Paula",
+                    "_": ""
+                },
+                {
+                    "n": "MD",
+                    "r": "ND",
+                    "s": "Souto",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Assist\u00eancia \u00e0 Sa\u00fade da Crian\u00e7a com C\u00e2ncer na Produ\u00e7\u00e3o Cient\u00edfica Brasileira"
+                }
+            ],
+            "code": "S1851-8265201800010005100014"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2002"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "249",
+                    "f": "237",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "237-49"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Health &amp; Place"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "15"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "15"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "8"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20020000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "19"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100015"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "D",
+                    "r": "ND",
+                    "s": "Scott",
+                    "_": ""
+                },
+                {
+                    "n": "B",
+                    "r": "ND",
+                    "s": "Curtis",
+                    "_": ""
+                },
+                {
+                    "n": "FO",
+                    "r": "ND",
+                    "s": "Twumasi",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Towards the creation of a health information system for cancer in KwaZulu-Natal, South Africa"
+                }
+            ],
+            "code": "S1851-8265201800010005100015"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2011"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "1189",
+                    "f": "1180",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "1180-9"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "International Journal of Cancer"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "16"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "16"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "5"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "129"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20110000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "20"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100016"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "MR",
+                    "r": "ND",
+                    "s": "Bailony",
+                    "_": ""
+                },
+                {
+                    "n": "MK",
+                    "r": "ND",
+                    "s": "Hararah",
+                    "_": ""
+                },
+                {
+                    "n": "AR",
+                    "r": "ND",
+                    "s": "Salhab",
+                    "_": ""
+                },
+                {
+                    "n": "I",
+                    "r": "ND",
+                    "s": "Ghannam",
+                    "_": ""
+                },
+                {
+                    "n": "Z",
+                    "r": "ND",
+                    "s": "Abdeen",
+                    "_": ""
+                },
+                {
+                    "n": "J",
+                    "r": "ND",
+                    "s": "Ghannam",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Cancer registration and healthcare access in West Bank, Palestine: a GIS analysis of childhood cancer, 1998-2007"
+                }
+            ],
+            "code": "S1851-8265201800010005100016"
+        },
+        {
+            "v71": [
+                {
+                    "_": "thesis"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Campinas"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2015"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "JKO",
+                    "r": "ND",
+                    "s": "Friestino",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "17"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "Panorama do c\u00e2ncer em crian\u00e7as e adolescentes sob a perspectiva da sa\u00fade coletiva"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "17"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "Universidade Estadual de Campinas"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20150000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "21"
+                }
+            ],
+            "v61": [
+                {
+                    "_": "Teses de Doutorado"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100017"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100017"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2016"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "8",
+                    "f": "1",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "1-8"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "International Archives of Medicine"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "18"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "18"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "152"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "9"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20160000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "22"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100018"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "JK",
+                    "r": "ND",
+                    "s": "Oliveira-Friestino",
+                    "_": ""
+                },
+                {
+                    "n": "PMB",
+                    "r": "ND",
+                    "s": "Francisco",
+                    "_": ""
+                },
+                {
+                    "n": "DC",
+                    "r": "ND",
+                    "s": "Moreira Filho",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Incidence profile of leukemias, lymphomas, central nervous system tumors and soft-tissue sarcomas in children and adolescents in a brazilian city"
+                }
+            ],
+            "code": "S1851-8265201800010005100018"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2005"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "1467",
+                    "f": "1457",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "1457-67"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Cancer"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "19"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "19"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "7"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "103"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20050000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "23"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100019"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                },
+                {
+                    "n": "C",
+                    "r": "ND",
+                    "s": "Stiller",
+                    "_": ""
+                },
+                {
+                    "n": "B",
+                    "r": "ND",
+                    "s": "Lacour",
+                    "_": ""
+                },
+                {
+                    "n": "P",
+                    "r": "ND",
+                    "s": "Kaatsch",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Classification of Childhood Cancer, Third Edition"
+                }
+            ],
+            "code": "S1851-8265201800010005100019"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Geneva"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "1966"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v16": [
+                {
+                    "n": "R",
+                    "r": "ND",
+                    "s": "Doll",
+                    "_": ""
+                },
+                {
+                    "n": "P",
+                    "r": "ND",
+                    "s": "Payne",
+                    "_": ""
+                },
+                {
+                    "n": "JAH",
+                    "r": "ND",
+                    "s": "Waterhouse",
+                    "_": ""
+                }
+            ],
+            "v701": [
+                {
+                    "_": "20"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "Cancer incidence in five continents"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "20"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "Union Internationale Contre le Cancer"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19660000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "24"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100020"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100020"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "1987"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "681",
+                    "f": "671",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "671-81"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Biometrics"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "21"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "21"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "43"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19870000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "25"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100021"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "D",
+                    "r": "ND",
+                    "s": "Clayton",
+                    "_": ""
+                },
+                {
+                    "n": "J",
+                    "r": "ND",
+                    "s": "Kaldor",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Empirical Bayes estimates of age-standardized relative risks for use in disease mapping"
+                }
+            ],
+            "code": "S1851-8265201800010005100021"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2001"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v514": [
+                {
+                    "l": "1098",
+                    "f": "1083",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "1083-98"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Cadernos de Sa\u00fade P\u00fablica"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "22"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "22"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "17"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20010000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "26"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100022"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "TC",
+                    "r": "ND",
+                    "s": "Bailey",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Spatial statistical methods in health"
+                }
+            ],
+            "code": "S1851-8265201800010005100022"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2003"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "25",
+                    "f": "11",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "11-25"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Biostatistics"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "23"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "23"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20030000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "27"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100023"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "AE",
+                    "r": "ND",
+                    "s": "Gelfand",
+                    "_": ""
+                },
+                {
+                    "n": "P",
+                    "r": "ND",
+                    "s": "Vounatsou",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Proper multivariate conditional autoregressive models for spatial data analysis"
+                }
+            ],
+            "code": "S1851-8265201800010005100023"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2015"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "498",
+                    "f": "489",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "489-98"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Osteoporosis International"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "24"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "24"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "2"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "26"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20150000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "28"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100024"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "CM",
+                    "r": "ND",
+                    "s": "Oliveira",
+                    "_": ""
+                },
+                {
+                    "n": "T",
+                    "r": "ND",
+                    "s": "Economou",
+                    "_": ""
+                },
+                {
+                    "n": "T",
+                    "r": "ND",
+                    "s": "Bailey",
+                    "_": ""
+                },
+                {
+                    "n": "D",
+                    "r": "ND",
+                    "s": "Mendonca",
+                    "_": ""
+                },
+                {
+                    "n": "MF",
+                    "r": "ND",
+                    "s": "Pina",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "The interactions between municipal socioeconomic status and age on hip fracture risk"
+                }
+            ],
+            "code": "S1851-8265201800010005100024"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2000"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "337",
+                    "f": "325",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "325-37"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Statistics and Computing"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "25"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "25"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "4"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "10"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20000000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "29"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100025"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "DJ",
+                    "r": "ND",
+                    "s": "Lunn",
+                    "_": ""
+                },
+                {
+                    "n": "A",
+                    "r": "ND",
+                    "s": "Thomas",
+                    "_": ""
+                },
+                {
+                    "n": "N",
+                    "r": "ND",
+                    "s": "Best",
+                    "_": ""
+                },
+                {
+                    "n": "D",
+                    "r": "ND",
+                    "s": "Spiegelhalter",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "WinBUGS-a Bayesian modelling framework: concepts, structure, and extensibility"
+                }
+            ],
+            "code": "S1851-8265201800010005100025"
+        },
+        {
+            "v71": [
+                {
+                    "_": "software"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Austria"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2012"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v109": [
+                {
+                    "_": "16 oct 2016"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "26"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "R: a language and environment for statistical computing"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "26"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "R Foundation for Statistical Computing"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20120000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v37": [
+                {
+                    "_": "https://www.r-project.org/"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "30"
+                }
+            ],
+            "v61": [
+                {
+                    "_": "Disponible en: https://www.r-project.org/"
+                }
+            ],
+            "v17": [
+                {
+                    "_": "RC Team"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100026"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100026"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2012"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "676",
+                    "f": "663",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "663-76"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Pediatric Hematology and Oncology"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "27"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "27"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "7"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "29"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20120000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "31"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100027"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "H",
+                    "r": "ND",
+                    "s": "Carreira",
+                    "_": ""
+                },
+                {
+                    "n": "L",
+                    "r": "ND",
+                    "s": "Antunes",
+                    "_": ""
+                },
+                {
+                    "n": "C",
+                    "r": "ND",
+                    "s": "Castro",
+                    "_": ""
+                },
+                {
+                    "n": "N",
+                    "r": "ND",
+                    "s": "Lunet",
+                    "_": ""
+                },
+                {
+                    "n": "MJ",
+                    "r": "ND",
+                    "s": "Bento",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Cancer incidence and survival (1997-2006) among adolescents and young adults in the north of Portugal"
+                }
+            ],
+            "code": "S1851-8265201800010005100027"
+        },
+        {
+            "v71": [
+                {
+                    "_": "book"
+                }
+            ],
+            "v66": [
+                {
+                    "_": "Lyon"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2014"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "collection": "spa",
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "28"
+                }
+            ],
+            "v18": [
+                {
+                    "_": "World Cancer Report 2014"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "28"
+                }
+            ],
+            "v62": [
+                {
+                    "_": "WHO"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20140000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "32"
+                }
+            ],
+            "v17": [
+                {
+                    "_": "International Agency for Research on Cancer"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100028"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "code": "S1851-8265201800010005100028"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2004"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "253",
+                    "f": "237",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "237-53"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Pediatric Hematology and Oncology"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "29"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "29"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "21"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20040000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100029"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "N",
+                    "r": "ND",
+                    "s": "Yaris",
+                    "_": ""
+                },
+                {
+                    "n": "A",
+                    "r": "ND",
+                    "s": "Mandiracioglu",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "B\u00fcy\u00fckpamukcuc",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Childhood cancer in developing countries"
+                }
+            ],
+            "code": "S1851-8265201800010005100029"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2004"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "2105",
+                    "f": "2097",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "2097-105"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Lancet"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "30"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "30"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "9451"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "364"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20040000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "34"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100030"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                },
+                {
+                    "n": "C",
+                    "r": "ND",
+                    "s": "Stiller",
+                    "_": ""
+                },
+                {
+                    "n": "P",
+                    "r": "ND",
+                    "s": "Kaatsch",
+                    "_": ""
+                },
+                {
+                    "n": "F",
+                    "r": "ND",
+                    "s": "Berrino",
+                    "_": ""
+                },
+                {
+                    "n": "JW",
+                    "r": "ND",
+                    "s": "Coebergh",
+                    "_": ""
+                },
+                {
+                    "n": "B",
+                    "r": "ND",
+                    "s": "Lacour",
+                    "_": ""
+                },
+                {
+                    "n": "M",
+                    "r": "ND",
+                    "s": "Parkin",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Geographical patterns and time trends of cancer incidence and survival among children and adolescents in Europe since the 1970s (the ACCIS project): an epidemiological study"
+                }
+            ],
+            "code": "S1851-8265201800010005100030"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2006"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "2018",
+                    "f": "2006",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "2006-18"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "European Journal of Cancer"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "31"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "31"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "13"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "42"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20060000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "35"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100031"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "CA",
+                    "r": "ND",
+                    "s": "Stiller",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Desandes",
+                    "_": ""
+                },
+                {
+                    "n": "SE",
+                    "r": "ND",
+                    "s": "Danon",
+                    "_": ""
+                },
+                {
+                    "n": "I",
+                    "r": "ND",
+                    "s": "Izarzugaza",
+                    "_": ""
+                },
+                {
+                    "n": "A",
+                    "r": "ND",
+                    "s": "Ratiu",
+                    "_": ""
+                },
+                {
+                    "n": "Z",
+                    "r": "ND",
+                    "s": "Vassileva-Valerianova",
+                    "_": ""
+                },
+                {
+                    "n": "E",
+                    "r": "ND",
+                    "s": "Steliarova-Foucher",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Cancer incidence and survival in European adolescents (1978-1997)"
+                }
+            ],
+            "code": "S1851-8265201800010005100031"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2002"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "44",
+                    "f": "33",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "33-44"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Cadernos de Sa\u00fade P\u00fablica"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "32"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "32"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "18"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20020000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "36"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100032"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "PE",
+                    "r": "ND",
+                    "s": "Braga",
+                    "_": ""
+                },
+                {
+                    "n": "MRDO",
+                    "r": "ND",
+                    "s": "Latorre",
+                    "_": ""
+                },
+                {
+                    "n": "MP",
+                    "r": "ND",
+                    "s": "Curado",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Childhood cancer: a comparative analysis of incidence, mortality, and survival in Goiania (Brazil) and other countries"
+                }
+            ],
+            "code": "S1851-8265201800010005100032"
+        },
+        {
+            "v71": [
+                {
+                    "_": "journal"
+                }
+            ],
+            "v702": [
+                {
+                    "_": "scol/v14n1/1851-8265-scol-14-01-51.xml"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "collection": "spa",
+            "v705": [
+                {
+                    "_": "S"
+                }
+            ],
+            "v64": [
+                {
+                    "_": "2016"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v882": [
+                {
+                    "v": "14",
+                    "n": "1",
+                    "_": ""
+                }
+            ],
+            "v936": [
+                {
+                    "y": "2018",
+                    "i": "1851-8265",
+                    "o": "1",
+                    "_": ""
+                }
+            ],
+            "v514": [
+                {
+                    "l": "e96",
+                    "f": "e88",
+                    "_": ""
+                }
+            ],
+            "v14": [
+                {
+                    "_": "e88-96"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Pediatric Hematology and Oncology"
+                }
+            ],
+            "processing_date": "2018-07-14",
+            "v2": [
+                {
+                    "_": "S1851-8265(18)01400100051"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "c"
+                }
+            ],
+            "v118": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "3"
+                }
+            ],
+            "v708": [
+                {
+                    "_": "33"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "8"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20160000"
+                }
+            ],
+            "v865": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "37"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "S1851-8265201800010005100033"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v14n1"
+                }
+            ],
+            "v10": [
+                {
+                    "n": "NV",
+                    "r": "ND",
+                    "s": "Balmant",
+                    "_": ""
+                },
+                {
+                    "n": "RDS",
+                    "r": "ND",
+                    "s": "Reis",
+                    "_": ""
+                },
+                {
+                    "n": "JFP",
+                    "r": "ND",
+                    "s": "Oliveira",
+                    "_": ""
+                },
+                {
+                    "n": "S",
+                    "r": "ND",
+                    "s": "Ferman",
+                    "_": ""
+                },
+                {
+                    "n": "MDO",
+                    "r": "ND",
+                    "s": "Santos",
+                    "_": ""
+                },
+                {
+                    "n": "BD",
+                    "r": "ND",
+                    "s": "Camargo",
+                    "_": ""
+                }
+            ],
+            "v12": [
+                {
+                    "_": "Cancer incidence among adolescents and young adults (15 to 29 years) in Brazil"
+                }
+            ],
+            "code": "S1851-8265201800010005100033"
+        }
+    ],
+    "code_issue": "1851-826520180001",
+    "issue": {
+        "created_at": "2018-07-12",
+        "code_title": [
+            "1669-2381",
+            "1851-8265"
+        ],
+        "collection": "spa",
+        "publication_date": "2018-03",
+        "issue_type": "regular",
+        "publication_year": "2018",
+        "processing_date": "2018-07-12",
+        "issue": {
+            "v122": [
+                {
+                    "_": "11"
+                }
+            ],
+            "v935": [
+                {
+                    "_": "1669-2381"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v36": [
+                {
+                    "_": "20181"
+                }
+            ],
+            "v35": [
+                {
+                    "_": "1851-8265"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Salud Colectiva"
+                }
+            ],
+            "processing_date": "2018-07-12",
+            "v48": [
+                {
+                    "l": "es",
+                    "h": "Sumario",
+                    "_": ""
+                },
+                {
+                    "l": "pt",
+                    "h": "Sumario",
+                    "_": ""
+                },
+                {
+                    "l": "en",
+                    "h": "Table of Contents",
+                    "_": ""
+                }
+            ],
+            "v31": [
+                {
+                    "_": "14"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "20180300"
+                }
+            ],
+            "v42": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v151": [
+                {
+                    "_": "Salud Colectiva"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "1851-826520180001"
+                }
+            ],
+            "v4": "v14n1",
+            "v230": [
+                {
+                    "_": "/api/v1/sponsors/20/"
+                }
+            ],
+            "v49": [
+                {
+                    "l": "en",
+                    "c": "SCOL-86tc",
+                    "t": "Editorial",
+                    "_": ""
+                },
+                {
+                    "l": "en",
+                    "c": "SCOL-x5c5",
+                    "t": "Articles",
+                    "_": ""
+                },
+                {
+                    "l": "es",
+                    "c": "SCOL-86tc",
+                    "t": "Editorial",
+                    "_": ""
+                },
+                {
+                    "l": "es",
+                    "c": "SCOL-x5c5",
+                    "t": "Art\u00edculos",
+                    "_": ""
+                }
+            ],
+            "v541": [
+                {
+                    "_": "BY-NC/4.0"
+                }
+            ],
+            "v999": [
+                {
+                    "_": "../bases-work/scol/scol"
+                }
+            ],
+            "v421": [
+                {
+                    "_": "Salud Colect"
+                }
+            ],
+            "collection": "spa",
+            "v117": [
+                {
+                    "_": "other"
+                }
+            ],
+            "v480": [
+                {
+                    "_": "Universidad Nacional de Lan\u00fas"
+                }
+            ],
+            "v91": [
+                {
+                    "_": "20180712"
+                }
+            ],
+            "v43": [
+                {
+                    "v": "vol.14",
+                    "c": "Lan\u00fas",
+                    "n": "no.1",
+                    "_": "",
+                    "a": "2018",
+                    "l": "es",
+                    "t": "Salud Colectiva",
+                    "m": "ene./mar."
+                },
+                {
+                    "v": "vol.14",
+                    "c": "Lan\u00fas",
+                    "n": "no.1",
+                    "_": "",
+                    "a": "2018",
+                    "l": "pt",
+                    "t": "Salud Colectiva",
+                    "m": "Jan./Mar."
+                },
+                {
+                    "v": "vol.14",
+                    "c": "Lan\u00fas",
+                    "n": "n.1",
+                    "_": "",
+                    "a": "2018",
+                    "l": "en",
+                    "t": "Salud Colectiva",
+                    "m": "Jan./Mar."
+                }
+            ],
+            "v85": [
+                {
+                    "_": "decs"
+                }
+            ],
+            "v435": [
+                {
+                    "_": "1851-8265",
+                    "t": "ONLIN"
+                },
+                {
+                    "_": "1669-2381",
+                    "t": "PRINT"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "i"
+                }
+            ],
+            "v200": [
+                {
+                    "_": "0"
+                }
+            ],
+            "v930": [
+                {
+                    "_": "scol"
+                }
+            ],
+            "v130": [
+                {
+                    "_": "Salud Colectiva"
+                }
+            ],
+            "v540": [
+                {
+                    "l": "es",
+                    "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>.",
+                    "_": ""
+                },
+                {
+                    "l": "pt",
+                    "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>.",
+                    "_": ""
+                },
+                {
+                    "l": "en",
+                    "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc/4.0/\">Creative Commons Attribution-NonCommercial 4.0 International License</a>.",
+                    "_": ""
+                }
+            ],
+            "v32": [
+                {
+                    "_": "1"
+                }
+            ],
+            "code": "1851-826520180001"
+        },
+        "code": "1851-826520180001"
+    },
+    "code": "S1851-82652018000100051"
+}

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -1,35 +1,160 @@
 # coding: utf-8
+import json
+import os
+from datetime import datetime
+from io import BytesIO
+from unittest import skip
+
 from bs4 import BeautifulSoup
+from lxml import etree
+from mock import patch, call
+from xylose.scielodocument import Article
 
 from base import BaseTestCase
-from opac_proc.core.assets import Assets
+from opac_proc.core.assets import Assets, AssetXML, AssetHTMLS
+from opac_proc.core.ssm_handler import SSMHandler
 from opac_proc.web import config
+
+
+XML_TEST_CONTENT = """<?xml version="1.0" encoding="utf-8"?>
+<article xmlns:xlink="http://www.w3.org/1999/xlink">
+    <body>
+        <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf03.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf04.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf05.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.tif"/>
+    	<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.tif"/>
+    </body>
+</article>"""
+
+ssm_in_memory = {}
+
+
+class MockedXyloseJournal:
+    def __init__(self):
+        self.acronym = u'test'
+        self.scielo_issn = u'0101-0101'
+
+    def any_issn(self):
+        return u'0101-0101'
+
+
+class MockedXyloseArticle:
+    def __init__(self):
+        self.collection_acronym = u'scl'
+        self.journal = MockedXyloseJournal()
+        self.assets_code = u'v2n1'
+        self.data_model_version = 'xml'
+        self.doi = u'10.2564/0101-01012018000100001'
+        self.publisher_id = u'S0101-01012018000100001'
+
+    def original_language(self, *kwargs):
+        return u'es'
+
+    def file_code(self, *kwargs):
+        return u'xml_file'
+
+
+class SSMHandlerStub(SSMHandler):
+
+    def __init__(self, pfile=None, filename=None, filetype=None, metadata=None,
+                 bucket_name=None, attempts=5, sleep_attempts=2):
+        """SSM handler Stub."""
+        self.pfile = pfile
+        self.name = filename
+        self.filetype = filetype
+        self.metadata = metadata or {}
+        self.bucket_name = bucket_name
+        self.uuid = None
+        self.attempts = attempts
+        self.sleep_attempts = sleep_attempts
+
+    def exists(self):
+        if ssm_in_memory:
+            asset = ssm_in_memory.get(self._checksum_sha256)
+            if asset:
+                return 1, [asset]
+            else:
+                assets_by_filename = [
+                    asset
+                    for asset in ssm_in_memory.values()
+                    if asset['filename'] == self.name
+                ]
+                if assets_by_filename:
+                    return 2, assets_by_filename
+                return 0, []
+        else:
+            return 0, []
+
+    def remove(self):
+        ssm_in_memory.clear()
+
+    def get_asset(self, uuid):
+        return ssm_in_memory
+
+    def register(self):
+        self.metadata['registration_date'] = datetime.now().isoformat()
+        self.uuid = '123456789-123456789'
+        url_path = u'media/assets/{}/{}'.format(self.bucket_name,
+                                                self.name)
+        asset = {
+            'uuid': self.uuid,
+            'pfile': self.pfile,
+            'filename': self.name,
+            'filetype': self.filetype,
+            'metadata': self.metadata,
+            'bucket_name': self.bucket_name,
+            'absolute_url': url_path,
+            'full_absolute_url': '{}/{}'.format('ssm.scielo.org', url_path)
+        }
+        ssm_in_memory.update({self._checksum_sha256: asset})
+        return self.uuid
+
+    def get_urls(self):
+        return {
+            'url_path': u'media/assets/{}/{}'.format(self.bucket_name,
+                                                     self.name)
+        }
 
 
 class TestAssets(BaseTestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        try:
+            fixtures_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+            article_file_path = os.path.join(fixtures_path,
+                                             'article.json')
+            cls._json_file = open(article_file_path)
+            cls._article_json = cls._json_file.read()
+            cls._article_xml = os.path.join(fixtures_path,
+                                            '1851-8265-scol-14-01-51.xml')
+        except Exception:
+            pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._json_file.close()
+
     def setUp(self):
-        class MockedXyloseJournal:
-            def __init__(self):
-                self.acronym = 'test'
-
-        class MockedXyloseArticle:
-            def __init__(self):
-                self.journal = MockedXyloseJournal()
-                self.assets_code = '0001-0203'
-                self.data_model_version = 'xml'
-
         self.mocked_xylose_article = MockedXyloseArticle()
+        self.xml_content = etree.fromstring(
+            XML_TEST_CONTENT,
+            etree.XMLParser(remove_blank_text=True)
+        )
+        ssm_in_memory.clear()
 
     def test_article_transform_html_extract_media(self):
         self.mocked_xylose_article.data_model_version = 'html'
-        asset = Assets(self.mocked_xylose_article)
-        asset.content = """
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        asset._content = """
         <!-- <img src="/img/revistas/aabc/v76n4/a01img00.gif " /> -->
         <p align="center"><img src="/img/revistas/aabc/v76n4/a01img26.gif " /></p>
         <p><font size="2" face="verdana"> Here, <img src="/img/revistas/aabc/v76n4/a01img27.gif" align="absmiddle" />,<font face="symbol">    \xbc</font>, <img src="/img/revistas/aabc/v76n4/a01img28.gif" align="absmiddle" />    are the eigenvalues of <i>A</i> = \x96<i>dg</i>, where <i>g</i> : <i>M<sup>n</sup></i>    <font face="symbol">\xae</font> <i>S<sup>n</sup></i>(1) is the Gauss map of the    hypersurface. Reilly showed that orientable hypersurfaces with <i>S<sub>r</sub></i><sub>+1</sub>    = 0 are critical points of the functional </font></p>     <p align="center"><img src="/img/revistas/aabc/v76n4/a01img01.gif " /></p>
         """
-        html_soup = BeautifulSoup(asset.content, "html.parser")
+        html_soup = BeautifulSoup(asset._content, "html.parser")
         expected = [
             img.get('src').strip().encode('utf-8')
             for img in html_soup.find_all(src=True)
@@ -40,8 +165,8 @@ class TestAssets(BaseTestCase):
 
     def test_article_transform_html_extract_media_external_links(self):
         self.mocked_xylose_article.data_model_version = 'html'
-        asset = Assets(self.mocked_xylose_article)
-        asset.content = """
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        asset._content = """
         <!-- <img src="/img/revistas/aabc/v76n4/a01img00.gif " /> -->
         <p align="center"><img src="/img/revistas/aabc/v76n4/a01img26.gif " /></p>
         <p>Here, <img src="/img/revistas/aabc/v76n4/a01img27.gif" align="absmiddle" />
@@ -60,20 +185,10 @@ class TestAssets(BaseTestCase):
         self.assertEqual(len(medias), 3)
         self.assertEqual(medias, expected)
 
-    def test_article_transform_xml_extract_media(self):
-        self.mocked_xylose_article.data_model_version = 'xml'
-        asset = Assets(self.mocked_xylose_article)
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article xmlns:xlink="http://www.w3.org/1999/xlink">
-            <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf03.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf04.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf05.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.tif"/>
-        </article>"""
-        asset.content = unicode(xml_content)
+    @patch.object(AssetXML, '_get_content')
+    def test_article_transform_xml_extract_media(self, mocked_get_content):
+        mocked_get_content.return_value = XML_TEST_CONTENT
+        asset = AssetXML(self.mocked_xylose_article)
         expected = [
             "1414-431X-bjmbr-1414-431X20176177-gf01.tif",
             "1414-431X-bjmbr-1414-431X20176177-gf02.tif",
@@ -87,20 +202,25 @@ class TestAssets(BaseTestCase):
         self.assertEqual(len(medias), 7)
         self.assertEqual(medias, expected)
 
-    def test_article_transform_xml_extract_media_valid_extensions(self):
-        self.mocked_xylose_article.data_model_version = 'xml'
-        asset = Assets(self.mocked_xylose_article)
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+    @patch.object(AssetXML, '_get_content')
+    def test_article_transform_xml_extract_media_valid_extensions(
+        self,
+        mocked_get_content
+    ):
+        xml_test_content = """<?xml version="1.0" encoding="utf-8"?>
         <article xmlns:xlink="http://www.w3.org/1999/xlink">
-            <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.jpg"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf03.gif"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf04.exe"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf05.xls"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.avi"/>
-			<graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.csv"/>
+            <body>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf01.tif"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf02.jpg"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf03.gif"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf04"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf05.doc"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf06.avi"/>
+                <graphic mimetype="image" xlink:href="1414-431X-bjmbr-1414-431X20176177-gf07.xls"/>
+            </body>
         </article>"""
-        asset.content = unicode(xml_content)
+        mocked_get_content.return_value = xml_test_content
+        asset = AssetXML(self.mocked_xylose_article)
         expected = [
             "1414-431X-bjmbr-1414-431X20176177-gf01.tif",
             "1414-431X-bjmbr-1414-431X20176177-gf02.jpg",
@@ -163,3 +283,519 @@ class TestAssets(BaseTestCase):
         media_path = asset._get_media_path(name)
         self.assertIsNotNone(media_path)
         self.assertEqual(media_path, expected)
+
+    @patch.object(AssetXML, '_get_file_name')
+    def test_AssetXML_set_file_type_and_name(
+        self,
+        mocked_get_file_name
+    ):
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        self.assertEqual(asset_xml._file_type,
+                         self.mocked_xylose_article.data_model_version)
+        mocked_get_file_name.assert_called_once_with(asset_xml._file_type)
+
+    @patch.object(AssetXML, 'get_assets')
+    def test_AssetXML_set_content_error_if_there_is_no_xml_asset(
+        self,
+        mocked_get_assets
+    ):
+        mocked_get_assets.return_value = {}
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        self.assertIsNone(asset_xml._content)
+
+    @patch.object(etree, 'parse')
+    def test_AssetXML_get_content_file_not_found(
+        self,
+        mocked_etree_parse
+    ):
+        mocked_etree_parse.side_effect = Exception('File not found!')
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        self.assertIsNone(asset_xml._content)
+
+    @patch.object(AssetXML, '_get_content')
+    def test_xml_get_media(self, mocked_get_content):
+        mocked_get_content.return_value = self.xml_content
+        asset = AssetXML(self.mocked_xylose_article)
+        expected = [
+            "1414-431X-bjmbr-1414-431X20176177-gf01.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf02.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf03.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf04.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf05.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf06.tif",
+            "1414-431X-bjmbr-1414-431X20176177-gf07.tif"
+        ]
+        for count, media in enumerate(asset._get_media()):
+            element, attrib_key = media
+            self.assertEqual(element.attrib[attrib_key], expected[count])
+
+    def test_normalize_media_path_returns_normalized_path(self):
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        input_expected = [
+            ("graphic.tif", "graphic.jpg"),
+            ("image.gif", "image.gif"),
+            ("table", "table"),
+            ("abc/v21n4/graphic.tif", "abc/v21n4/graphic.jpg")
+        ]
+        for input, expected in input_expected:
+            media_path = asset_xml._normalize_media_path(input)
+            self.assertEqual(media_path, expected)
+
+    def setup_register_xml_medias_tests(self):
+        self.medias_bytes = [BytesIO(str(n)) for n in range(7)]
+        self.filenames = [
+            "1414-431X-bjmbr-1414-431X20176177-gf0{}.jpg".format(count)
+            for count in range(1, 8)
+        ]
+
+    def generate_metadata(self, filename, asset_xml):
+        metadata = asset_xml.get_metadata()
+        metadata.update({
+            'origin_path': os.path.splitext(filename)[0] + '.tif',
+            'file_path': filename,
+            'bucket_name': asset_xml.bucket_name,
+            'type': 'img'
+        })
+        return metadata
+
+    @patch('opac_proc.core.assets.SSMHandler')
+    def test_register_ssm_media_error_if_sss_handler_exception(
+        self,
+        MockedSSMHandler
+    ):
+        MockedSSMHandler.side_effect = Exception()
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with self.assertRaises(Exception):
+            asset_xml._register_ssm_media()
+
+    @patch.object(SSMHandler, 'exists')
+    def test_register_ssm_media_error_if_handler_method_exception(
+        self,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.side_effect = Exception()
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with self.assertRaises(Exception):
+            asset_xml._register_ssm_media()
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_media_register_if_ssm_asset_doesnt_exist(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (0, [])
+        mocked_ssmhandler_get_urls.return_value = {
+            'url': u'http://ssm.scielo.org/media/assets/4853/filename_t8krr12',
+            'url_path': u'/media/assets/4853/filename_t8krr12'
+        }
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_media(
+            BytesIO('1'),
+            'image.jpg',
+            'img',
+            self.generate_metadata('image.jpg', asset_xml)
+        )
+        mocked_ssmhandler_remove.assert_not_called()
+        mocked_ssmhandler_register.assert_called_once()
+        self.assertEqual(u'/media/assets/4853/filename_t8krr12', result)
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_media_returns_existing_ssm_asset_url(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (
+            1,
+            [{
+                'uuid': '1234-1234',
+                'url': u'http://ssm.scielo.org/media/assets/4853/filename_t8krr12',
+                'absolute_url': u'http://ssm.scielo.org/media/assets/4853/t8krr12'
+            }])
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_media(
+            BytesIO('1'),
+            'image.jpg',
+            'img',
+            self.generate_metadata('image.jpg', asset_xml)
+        )
+        mocked_ssmhandler_remove.assert_not_called()
+        mocked_ssmhandler_register.assert_not_called()
+        mocked_ssmhandler_get_urls.assert_not_called()
+        self.assertEqual(u'http://ssm.scielo.org/media/assets/4853/t8krr12',
+                         result)
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_media_change_asset_if_ssm_asset_exists_and_not_equal(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (2, [{'uuid': '1234-1234'}])
+        mocked_ssmhandler_get_urls.return_value = {
+            'url': u'http://ssm.scielo.org/media/assets/4853/filename_t8krr12',
+            'url_path': u'/media/assets/4853/filename_t8krr12'
+        }
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_media(
+            BytesIO('1'),
+            'image.jpg',
+            'img',
+            self.generate_metadata('image.jpg', asset_xml)
+        )
+        mocked_ssmhandler_remove.assert_called_once_with('1234-1234')
+        mocked_ssmhandler_register.assert_called_once()
+        self.assertEqual(u'/media/assets/4853/filename_t8krr12', result)
+
+    @patch('opac_proc.core.assets.SSMHandler')
+    def test_register_ssm_asset_error_if_sss_handler_exception(
+        self,
+        MockedSSMHandler
+    ):
+        MockedSSMHandler.side_effect = Exception()
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with self.assertRaises(Exception):
+            asset_xml._register_ssm_asset()
+
+    @patch('opac_proc.core.assets.SSMHandler')
+    def test_register_ssm_asset_new_sss_handler(
+        self,
+        MockedSSMHandler
+    ):
+        instance = MockedSSMHandler.return_value
+        instance.exists.return_value = (0, [])
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        pfile = BytesIO('1')
+        asset_xml._register_ssm_asset(
+            pfile,
+            'article.xml',
+            'xml',
+            asset_xml.get_metadata()
+        )
+        MockedSSMHandler.assert_called_once_with(
+            pfile,
+            'article.xml',
+            'xml',
+            asset_xml.get_metadata(),
+            asset_xml.bucket_name
+        )
+
+    @patch.object(SSMHandler, 'exists')
+    def test_register_ssm_asset_error_if_handler_method_exception(
+        self,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.side_effect = Exception()
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with self.assertRaises(Exception):
+            asset_xml._register_ssm_asset()
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_asset_register_if_ssm_asset_doesnt_exist(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (0, [])
+        mocked_ssmhandler_register.return_value = u'1234-1234'
+        mocked_ssmhandler_get_urls.return_value = {
+            'url': u'http://ssm.scielo.org/media/assets/4853/article.xml',
+            'url_path': u'/media/assets/4853/article.xml'
+        }
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_asset(
+            BytesIO('1'),
+            'article.xml',
+            'xml',
+            asset_xml.get_metadata()
+        )
+        mocked_ssmhandler_remove.assert_not_called()
+        self.assertEqual(
+            (u'1234-1234', u'/media/assets/4853/article.xml'), result)
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_asset_returns_existing_ssm_asset_url(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (
+            1,
+            [{
+                'uuid': '1234-1234',
+                'url': u'http://ssm.scielo.org/media/assets/4853/article.xml',
+                'full_absolute_url': u'http://ssm.scielo.org/media/assets/4853/article.xml'
+            }])
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_asset(
+            BytesIO('1'),
+            'article.xml',
+            'xml',
+            asset_xml.get_metadata()
+        )
+        mocked_ssmhandler_remove.assert_not_called()
+        mocked_ssmhandler_register.assert_not_called()
+        mocked_ssmhandler_get_urls.assert_not_called()
+        self.assertEqual(
+            ('1234-1234', u'http://ssm.scielo.org/media/assets/4853/article.xml'),
+            result)
+
+    @patch.object(SSMHandler, 'exists')
+    @patch.object(SSMHandler, 'remove')
+    @patch.object(SSMHandler, 'register')
+    @patch.object(SSMHandler, 'get_urls')
+    def test_register_ssm_asset_change_asset_if_ssm_asset_exists_and_not_equal(
+        self,
+        mocked_ssmhandler_get_urls,
+        mocked_ssmhandler_register,
+        mocked_ssmhandler_remove,
+        mocked_ssmhandler_exists
+    ):
+        mocked_ssmhandler_exists.return_value = (2, [{'uuid': '1234-1234'}])
+        mocked_ssmhandler_register.return_value = u'1234-1234'
+        mocked_ssmhandler_get_urls.return_value = {
+            'url': u'http://ssm.scielo.org/media/assets/4853/article.xml',
+            'url_path': u'/media/assets/4853/article.xml'
+        }
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        result = asset_xml._register_ssm_asset(
+            BytesIO('1'),
+            'article.xml',
+            'xml',
+            asset_xml.get_metadata()
+        )
+        mocked_ssmhandler_remove.assert_called_once_with('1234-1234')
+        self.assertEqual(
+            ('1234-1234', u'/media/assets/4853/article.xml'), result)
+
+    def test_register_xml_medias_no_medias(self):
+        def no_medias():
+            return
+            yield
+
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with patch.object(AssetXML, '_get_content'):
+            with patch.object(AssetXML, '_get_media') as \
+                    mocked_extract_media:
+                mocked_extract_media.side_effect = no_medias
+                asset_xml._register_xml_medias()
+
+    @patch.object(AssetXML, '_get_content')
+    @patch.object(AssetXML, '_open_asset')
+    @patch.object(AssetXML, '_register_ssm_media')
+    def test_register_xml_medias_error_if_ssm_handler_error(
+        self,
+        mocked_get_create_ssm_media,
+        mocked_open_asset,
+        mocked_get_content
+    ):
+        self.setup_register_xml_medias_tests()
+        mocked_open_asset.side_effect = self.medias_bytes
+        mocked_get_content.return_value = self.xml_content
+        mocked_get_create_ssm_media.side_effect = Exception()
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        with self.assertRaises(Exception):
+            asset_xml._register_xml_medias()
+
+    @patch.object(AssetXML, '_get_content')
+    @patch.object(AssetXML, '_open_asset')
+    @patch.object(AssetXML, '_register_ssm_media')
+    def test_register_xml_medias_register_all_ssm_assets(
+        self,
+        mocked_get_create_ssm_media,
+        mocked_open_asset,
+        mocked_get_content
+    ):
+        self.setup_register_xml_medias_tests()
+        mocked_open_asset.side_effect = self.medias_bytes
+        mocked_get_content.return_value = self.xml_content
+        mocked_get_create_ssm_media.side_effect = [
+            'data/' + filename
+            for filename in self.filenames
+        ]
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        medias_args = [
+            call(media,
+                 filename,
+                 "img",
+                 self.generate_metadata(filename, asset_xml))
+            for media, filename in zip(self.medias_bytes, self.filenames)
+        ]
+        asset_xml._register_xml_medias()
+        self.assertEqual(
+            mocked_get_create_ssm_media.mock_calls,
+            medias_args
+        )
+
+    @patch.object(AssetXML, '_get_content')
+    @patch.object(AssetXML, '_open_asset')
+    @patch.object(AssetXML, '_register_ssm_media')
+    def test_register_xml_medias_changes_content(
+        self,
+        mocked_get_create_ssm_media,
+        mocked_open_asset,
+        mocked_get_content
+    ):
+        self.setup_register_xml_medias_tests()
+        mocked_open_asset.side_effect = self.medias_bytes
+        mocked_get_content.return_value = self.xml_content
+        mocked_get_create_ssm_media.side_effect = [
+            'data/' + filename
+            for filename in self.filenames
+        ]
+        expected_xml = """<?xml version="1.0" encoding="utf-8"?>
+        <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <body>
+                <graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf01.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf02.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf03.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf04.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf05.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf06.jpg"/>
+            	<graphic mimetype="image" xlink:href="data/1414-431X-bjmbr-1414-431X20176177-gf07.jpg"/>
+            </body>
+        </article>"""
+        expected = etree.fromstring(expected_xml,
+                                    etree.XMLParser(remove_blank_text=True))
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        asset_xml._register_xml_medias()
+        self.assertEqual(
+            etree.tostring(expected.getroottree(), xml_declaration=True, encoding='utf-8'),
+            etree.tostring(asset_xml._content.getroottree(), xml_declaration=True, encoding='utf-8')
+        )
+
+    @patch('opac_proc.core.assets.HTMLGenerator.parse')
+    @patch.object(AssetXML, '_get_content')
+    def test_register_htmls_calls_packtools_html_generator_parse(
+        self,
+        mocked_get_content,
+        mocked_html_generator_parse
+    ):
+        mocked_get_content.return_value = self.xml_content
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        asset_xml.register_htmls()
+        mocked_html_generator_parse.assert_called_once_with(
+            self.xml_content,
+            valid_only=False,
+            css=config.OPAC_PROC_ARTICLE_CSS_URL,
+            print_css=config.OPAC_PROC_ARTICLE_PRINT_CSS_URL,
+            js=config.OPAC_PROC_ARTICLE_JS_URL
+        )
+
+    @patch('opac_proc.core.assets.HTMLGenerator.parse')
+    @patch('opac_proc.core.assets.logger.error')
+    @patch.object(AssetXML, '_get_content')
+    def test_register_htmls_log_error_if_packtools_html_generator_error(
+        self,
+        mocked_get_content,
+        mocked_logger_error,
+        mocked_html_generator_parse
+    ):
+        mocked_get_content.return_value = self.xml_content
+        mocked_html_generator_parse.side_effect = ValueError('invalid XML')
+        asset_xml = AssetXML(self.mocked_xylose_article)
+        asset_xml.register_htmls()
+        mocked_logger_error.assert_called_once_with(
+            'Error getting htmlgenerator: invalid XML.')
+
+    @patch('opac_proc.core.assets.etree.tostring')
+    @patch('opac_proc.core.assets.logger.error')
+    @patch.object(AssetXML, '_get_path')
+    def test_register_htmls_error_if_etree_tostring_error(
+        self,
+        mocked_get_path,
+        mocked_logger_error,
+        mocked_etree_tostring
+    ):
+        mocked_get_path.return_value = self._article_xml
+        mocked_etree_tostring.side_effect = Exception()
+        # Article in 'es' translated to 'en'
+        article_json = json.loads(self._article_json)
+        document = Article(article_json)
+        asset_xml = AssetXML(document)
+        asset_xml.register_htmls()
+        logger_calls = [
+            call('Error converting etree {} to string. '.format(lang))
+            for lang in ('es', 'en')
+        ]
+        self.assertEqual(
+            mocked_logger_error.mock_calls,
+            logger_calls
+        )
+
+    @patch('opac_proc.core.assets.logger.error')
+    @patch.object(AssetXML, '_get_path')
+    @patch.object(AssetXML, '_register_ssm_asset')
+    def test_register_htmls_error_if_register_ssm_error(
+        self,
+        mocked_register_ssm_asset,
+        mocked_get_path,
+        mocked_logger_error
+    ):
+        mocked_get_path.return_value = self._article_xml
+        mocked_register_ssm_asset.side_effect = Exception()
+        # Article in 'es' translated to 'en'
+        article_json = json.loads(self._article_json)
+        document = Article(article_json)
+        asset_xml = AssetXML(document)
+        with self.assertRaises(Exception):
+            asset_xml.register_htmls()
+
+    @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
+    @patch.object(AssetXML, '_get_path')
+    def test_register_htmls_generates_translated_htmls(self, mocked_get_path):
+        # Article in 'es' translated to 'en'
+        mocked_get_path.return_value = self._article_xml
+        article_json = json.loads(self._article_json)
+        document = Article(article_json)
+        asset_xml = AssetXML(document)
+        generated_htmls = asset_xml.register_htmls()
+        self.assertEqual(len(generated_htmls), 2)
+        self.assertEqual(generated_htmls[0]['type'], 'html')
+        self.assertEqual(generated_htmls[0]['lang'], 'es')
+        self.assertEqual(generated_htmls[1]['type'], 'html')
+        self.assertEqual(generated_htmls[1]['lang'], 'en')
+
+    @skip("LOCAL TEST ONLY")
+    @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
+    @patch.object(AssetXML, '_get_path')
+    def test_register_success(self, mocked_get_path):
+        mocked_get_path.return_value = self._article_xml
+        article_json = json.loads(self._article_json)
+        document = Article(article_json)
+        asset_xml = AssetXML(document)
+        uuid, xml_url = asset_xml.register()
+        self.assertIsNotNone(uuid)
+        self.assertIsNotNone(xml_url)
+        self.assertEqual(uuid, '123456789-123456789')
+        generated_htmls = asset_xml.register_htmls()
+        self.assertEqual(generated_htmls[0]['type'], 'html')
+        self.assertEqual(generated_htmls[0]['lang'], 'es')
+        self.assertEqual(generated_htmls[1]['type'], 'html')
+        self.assertEqual(generated_htmls[1]['lang'], 'en')

--- a/opac_proc/transformers/tr_articles.py
+++ b/opac_proc/transformers/tr_articles.py
@@ -182,7 +182,7 @@ class ArticleTransformer(BaseTransformer):
 
             if xml_url and uuid:
                 self.transform_model_instance['xml'] = xml_url
-                self.transform_model_instance['htmls'] = asset_html.register_from_xml(uuid)
+                self.transform_model_instance['htmls'] = asset_xml.register_htmls()
 
         # Versão HTML do artigo
         if hasattr(xylose_article, 'data_model_version') and xylose_article.data_model_version != 'xml':

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -236,7 +236,7 @@ PROMPG_URL = '%s://%s:%s' % (PROMPG_SCHEME, PROMPG_HOST, PROMPG_PORT)
 # Static files
 OPAC_PROC_STATIC_CATALOG = os.path.join(HERE, 'static', 'catalog')
 PDF_CATALOG_CRON_STRING = os.environ.get('OPAC_PROC_PDF_CATALOG_CRON_STRING',
-                                         '0 0 * * 0')
+                                         '0 2 1-31 * *')
 XML_CATALOG_CRON_STRING = os.environ.get('OPAC_PROC_XML_CATALOG_CRON_STRING',
-                                         '0 0 * * 0')
+                                         '0 2 1-31 * *')
 DEFAULT_SCHEDULER_TIMEOUT = int(os.environ.get('OPAC_PROC_DEFAULT_SCHEDULER_TIMEOUT', 2000))

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ Flask-Mail==0.9.1
 articlemetaapi==1.26.2
 prometheus-client==0.3.0
 beautifulsoup4==4.6.1
+mock==2.0.0


### PR DESCRIPTION
Fixes #330 

- Alteração no registro de artigos em XML e seus assets no SSM
- Alteração em `tr_articles` para utilizar a estrutura nova do AssetXML
- Criação de testes
- Ajuste na configuração padrão da geração do catálogo estático