### PR TITLE
Correção na transformação de artigos HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,14 @@ dev_compose_ps: get_opac_mongo_info get_opac_grpc_info
 dev_compose_rm: get_opac_mongo_info get_opac_grpc_info
 	@docker-compose -f $(COMPOSE_FILE_DEV) rm -f $<
 
-dev_compose_exec_shell_webapp: dev_compose_up
+dev_compose_exec_shell_webapp: get_opac_mongo_info get_opac_grpc_info
 	@docker-compose -f $(COMPOSE_FILE_DEV) exec webapp sh
 
-dev_compose_make_test: dev_compose_up
+dev_compose_make_test: get_opac_mongo_info get_opac_grpc_info
 	@docker-compose -f $(COMPOSE_FILE_DEV) exec webapp python opac_proc/manage.py test
+
+dev_compose_make_test_pattern: get_opac_mongo_info get_opac_grpc_info
+	@docker-compose -f $(COMPOSE_FILE_DEV) exec webapp python opac_proc/manage.py test -p $(pattern)
 
 dev_compose_top:
 	@docker-compose -f $(COMPOSE_FILE_DEV) top

--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -6,6 +6,7 @@ import os
 import re
 from copy import copy
 from io import BytesIO, open as io_open
+from urlparse import urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup
 from lxml import etree
@@ -360,6 +361,16 @@ class Assets(object):
 
         return u'{}{}.{}'.format(prefix, file_code, file_type)
 
+    def _is_valid_media_file(self, parsed_url):
+        if parsed_url.scheme and parsed_url.netloc:
+            return False
+        ext_files_list = [
+            '.' + extension
+            for extension in config.MEDIA_EXTENSION_FILES.split(',')
+        ]
+        ext_files_list.append('')   # arquivos sem extensão
+        return os.path.splitext(parsed_url.path)[-1] in ext_files_list
+
     def _normalize_media_path(self, media_path):
         root, ext = os.path.splitext(media_path)
         if ext == '.tif' or ext == '.tiff':
@@ -711,7 +722,6 @@ class AssetHTMLS2(Assets):
         - Media paths like:
           - img/fbpe
           - img/revistas
-          - videos
           must be replaced with OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
         - ../ or ./ must be replaced with /
         Return a tuple with original path and normalized path
@@ -738,22 +748,43 @@ class AssetHTMLS2(Assets):
         SSM/GRPC urls.
         Returns the updated parsed_html.
         """
+
+        def _find_all_media_paths(parsed_html):
+            return updated_html.find_all(src=True) +\
+                updated_html.find_all(href=True)
+
         file_type = 'img'  # Not all are images
         updated_html = copy(parsed_html)
-        for src_tag in updated_html.find_all(src=True):
-            original_path = src_tag.get('src').strip()
-            media_path = self._normalize_media_path(original_path)
-            pfile = self._open_asset(self._get_media_path(media_path))
-            if pfile:
-                metadata = self.get_metadata()
-                metadata.update({
-                    'bucket_name': self.bucket_name,
-                    'type': file_type,
-                    'version': 'html'
-                })
-                ssm_asset_url = self._register_ssm_media(
-                    pfile, media_path, file_type, metadata)
-                src_tag['src'] = ssm_asset_url
+        for tag in _find_all_media_paths(parsed_html):
+            tag_attr = 'src' if tag.get('src') else 'href'
+            original_path = tag[tag_attr].strip()
+            splited_url = urlsplit(original_path)
+            metadata = self.get_metadata()
+            metadata.update({'bucket_name': self.bucket_name,
+                             'type': file_type,
+                             'origin_path': original_path})
+            if self._is_valid_media_file(splited_url):
+                media_path = self._normalize_media_path(splited_url.path)
+                pfile = self._open_asset(media_path)
+                if pfile:
+                    metadata.update({'file_path': media_path})
+                    ssm_asset_url = self._register_ssm_media(
+                        pfile,
+                        os.path.basename(media_path),
+                        file_type,
+                        metadata)
+                    tag[tag_attr] = urlunsplit((
+                        '',
+                        '',
+                        ssm_asset_url,
+                        splited_url.query,
+                        splited_url.fragment))
+            elif os.path.splitext(splited_url.path)[-1].startswith('.htm'):
+                # O ativo digital é um HTML. É preciso fazer a transformação e
+                # o registro dos ativos digitais dentro dele.
+                html_media_path = self._normalize_media_path(splited_url.path)
+                html_file = self._open_asset(html_media_path)
+
         return updated_html
 
     def _add_htmls(self, htmls):

--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import imghdr
 import itertools
-import json
 import os
 import re
 from copy import copy
@@ -15,7 +14,6 @@ from packtools import HTMLGenerator
 from opac_proc.core import utils
 from opac_proc.logger_setup import getMongoLogger
 from opac_proc.web import config
-from html_generator import generate_htmls
 from ssm_handler import SSMHandler
 
 if config.DEBUG:
@@ -60,55 +58,12 @@ class Assets(object):
             else:
                 return None
 
-    def _change_img_path(self, medias):
-        """
-        Changes the path of the media in XML so that it is something accessible.
-        """
-
-        if medias:
-            for media_name, url in medias.items():
-                # test media_name is unicode?
-                if not isinstance(media_name, unicode):
-                    media_name = media_name.encode('utf-8')
-
-                # test url is unicode?
-                if not isinstance(url, unicode):
-                    url = url.encode('utf-8')
-
-                self._content = self._content.replace(media_name, url)
-
     def _is_external_link(self, path):
         ext_link_indicators = config.MEDIA_EXT_LINKS_IND.split(',')
         return any(
             map(lambda ext_link_ind: path.startswith(ext_link_ind),
                 ext_link_indicators)
         )
-
-    def _extract_media(self):
-        """
-        Return a list of media to be collect from content
-
-        Try get imgs by xlink:href and src tags with internal links.
-        """
-        if self.xylose.data_model_version == 'xml':
-            msg_error = "Método não deve ser usado para XMLs."
-            logger.error(msg_error)
-            raise TypeError(msg_error)
-
-        parser = "html.parser"
-        soup = BeautifulSoup(self._content, parser)
-        src_tags = [
-            tag.get('src').strip().encode('utf-8')
-            for tag in soup.find_all(src=True)
-        ]
-
-        medias = [
-            src_tag
-            for src_tag in src_tags
-            if not self._is_external_link(src_tag)
-        ]
-
-        return medias
 
     def _get_media_path(self, name):
         """
@@ -155,46 +110,6 @@ class Assets(object):
         logger.info(msg_info)
 
         return list(langs)
-
-    def _normalize_media_path_html(self, media_path):
-        """
-        This method takes the path to the media and fits to known paths
-        and returns a tuple with the media path in the original html,
-        the path known in the file system.
-
-        In addition to making some extrension adjustments
-
-        Params:
-            :param media_path: the path to the media.
-                Example of paths:
-                    /img/revistas/gs/v29n4/original_breve1_t1.jpg (must common example)
-                    /img/fbpe/gs/v29n4/original_breve1_t1.jpg
-                    ../img/revistas/gs/v29n4/original_breve1_t1.jpg
-                    img/revistas/resp/v80n6/seta.gif
-                    /img/revistas/resp/v80n6/seta.gif (this media is no registered)
-        """
-
-        origin_path = media_path
-
-        # TODO: Colocar um cadastro de mídias fixas para não alterar? Consulta
-        # que não seja feita a cada interação para não comprometer performance
-        exclude_medias = ['seta.jpg', 'seta.gif']
-
-        if os.path.basename(media_path) in exclude_medias:
-            return (origin_path, None)
-
-        source_media_path = config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
-
-        change_media_path = [('tif', 'jpg'), ('../', '/'), ('./', '/'),
-                             ('/img/fbpe', source_media_path),
-                             ('img/fbpe', source_media_path),
-                             ('/img/revistas', source_media_path),
-                             ('img/revistas', source_media_path)]
-
-        for _from, _to in change_media_path:
-            media_path = media_path.replace(_from, _to.lower())
-
-        return (origin_path, media_path)
 
     @property
     def bucket_name(self):
@@ -277,80 +192,6 @@ class Assets(object):
         metadata['issn'] = self.xylose.journal.any_issn()
 
         return metadata
-
-    def register_media_html(self):
-        """
-        Return a dictionary with all media added in SSM.
-
-        Example:  {
-                    'a08tab01.gif': 'http://ssm.scielo.org/media/assets/resp/v89n1/a08tab01.gif'
-                    'a08tab3b.gif': 'http://ssm.scielo.org/media/assets/resp/v89n1/a08tab3b.gif'
-                  }
-        """
-        file_type = 'img'  # Not all are images
-        registered_medias = {}
-
-        medias = self._extract_media()
-
-        for media in medias:
-
-            origin_path, media_path = self._normalize_media_path_html(media)
-
-            if not media_path:
-                continue
-
-            pfile = self._open_asset(media_path)
-
-            if not pfile:
-                continue
-
-            metadata = self.get_metadata()
-            metadata.update({'file_path': media_path,
-                             'bucket_name': self.bucket_name,
-                             'type': file_type,
-                             'origin_path': origin_path})
-
-            media_name = os.path.basename(media_path)
-
-            ssm_asset = SSMHandler(pfile, media_name, file_type, metadata,
-                                   self.bucket_name)
-
-            code, existing_asset = ssm_asset.exists()
-
-            # Existe mas não é identico (existe com o mesmo nome)
-            if code == 2:
-                logger.info(u"Já existe um media com PID: %s e colecao: %s, cadastrado: %s",
-                            self.xylose.publisher_id, self.xylose.collection_acronym, existing_asset)
-                logger.info(u"Lista de imagens com mesmo filename para o artigo com PID: %s, %s",
-                            self.xylose.publisher_id, existing_asset)
-                logger.info(u"Removendo a lista de images: %s", existing_asset)
-
-                for asset in existing_asset:
-                    ssm_asset.remove(asset['uuid'])
-
-            # Existe mas não é idêntico code=2, removido no passo anterior deve ser
-            # recadastrado, também deve ser cadastrado caso não exista, code=0.
-            if code == 2 or code == 0:
-                uuid = ssm_asset.register()
-
-                logger.info(u"UUID: %s para media do artigo com PID: %s",
-                            uuid, self.xylose.publisher_id)
-
-                registered_medias.update({origin_path: ssm_asset.get_urls()['url_path']})
-
-                logger.info(u"Medias(s): %s cadastrado(s) para o artigo com PID: %s",
-                            registered_medias, self.xylose.publisher_id)
-
-            # Existe e o ativo é idêntico
-            if code == 1:
-                for asset in existing_asset:
-                    metadata = json.loads(asset['metadata'])
-                    registered_medias.update({metadata['origin_path']:
-                                              asset['absolute_url']})
-
-                logger.info(u"Medias já existente no SSM: %s", registered_medias)
-
-        return registered_medias
 
     def _get_file_name(self, file_type, lang=None):
         original_lang = self.xylose.original_language()
@@ -729,16 +570,20 @@ class AssetHTMLS(Assets):
         media_path = super(AssetHTMLS, self)._normalize_media_path(
             original_path)
         source_media_path = config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
-        change_media_path = [('../', '/'), ('./', '/'),
-                             ('/img/fbpe', source_media_path),
-                             ('img/fbpe', source_media_path),
-                             ('/img/revistas', source_media_path),
-                             ('img/revistas', source_media_path),
-                             ('/videos', source_media_path),
-                             ('videos', source_media_path)]
-        for _from, _to in change_media_path:
-            media_path = media_path.replace(_from, _to.lower())
+        if re.findall(r'^\.[/|./]+', media_path):
+            media_path = self._get_media_path(os.path.basename(media_path))
+        else:
+            change_media_path = [('/img/fbpe', source_media_path),
+                                 ('img/fbpe', source_media_path),
+                                 ('/img/revistas', source_media_path),
+                                 ('img/revistas', source_media_path),
+                                 ('/videos', source_media_path),
+                                 ('videos', source_media_path)]
+            for _from, _to in change_media_path:
+                media_path = media_path.replace(_from, _to.lower())
 
+        logger.info("Path - original: {}, normalized: {}".format(
+                    original_path, media_path))
         return media_path
 
     def _register_html_media_asset(
@@ -769,25 +614,27 @@ class AssetHTMLS(Assets):
         Returns the updated parsed_html.
         """
 
-        def _find_all_media_paths(parsed_html):
+        def _find_all_media_paths(updated_html):
             return updated_html.find_all(src=True) +\
                 updated_html.find_all(href=True)
 
-        file_type = 'img'  # Not all are images
         updated_html = copy(parsed_html)
-        for tag in _find_all_media_paths(parsed_html):
+        for tag in _find_all_media_paths(updated_html):
             tag_attr = 'src' if tag.get('src') else 'href'
             original_path = tag[tag_attr].strip()
             splited_url = urlsplit(original_path)
             metadata = self.get_metadata()
             metadata.update({'bucket_name': self.bucket_name,
-                             'type': file_type,
                              'origin_path': original_path})
             if self._is_valid_media_file(splited_url):
                 media_path = self._normalize_media_path(splited_url.path)
                 pfile = self._open_asset(media_path)
                 if pfile:
-                    metadata.update({'file_path': media_path})
+                    file_type = 'img'  # Not all are images
+                    metadata.update({
+                        'file_path': media_path,
+                        'type': file_type
+                    })
                     url = self._register_html_media_asset(
                         splited_url,
                         pfile,
@@ -804,7 +651,11 @@ class AssetHTMLS(Assets):
                     parsed_html_asset = BeautifulSoup(html_file, "html.parser")
                     updated_html_asset = self._register_html_media_assets(
                         parsed_html_asset)
-                    metadata.update({'file_path': html_media_path})
+                    file_type = 'html'
+                    metadata.update({
+                        'file_path': html_media_path,
+                        'type': file_type
+                    })
                     url = self._register_html_media_asset(
                         splited_url,
                         BytesIO(updated_html_asset.encode('utf-8')),
@@ -889,176 +740,3 @@ class AssetHTMLS(Assets):
             logger.error(
                 u"Artigo com o PID: %s, não tem HTML", self.xylose.publisher_id
             )
-
-
-class AssetHTMLSOld(Assets):
-
-    def _get_name(self, lang):
-
-        original_lang = self.xylose.original_language()
-
-        file_code = self.xylose.file_code()
-
-        prefix = '' if lang == original_lang else '%s_' % lang
-
-        return u'{}{}.html'.format(prefix, file_code)
-
-    def generate_htmls(self, content, css=None, print_css=None, js=None):
-        """
-        Generates HTML contents from XML for all the text languages.
-        """
-        if not css:
-            css = config.OPAC_PROC_ARTICLE_CSS_URL
-        if not js:
-            js = config.OPAC_PROC_ARTICLE_JS_URL
-        if not print_css:
-            print_css = config.OPAC_PROC_ARTICLE_PRINT_CSS_URL
-
-        htmls, errors = generate_htmls(content, css, print_css, js)
-
-        if errors:
-            for error in errors:
-                logger.error("Erro gerando o HTML: %s", error)
-
-        return htmls
-
-    def add_htmls(self, htmls, xml_version=True):
-        """
-        Method to add html from a dictionary with language as key and the html
-        as value.
-
-        Params:
-            :param htmls: Dictionary {'lang': 'html'}
-            :param version: Indicates whether the html version is xml or not
-
-        Return a list of dictionary with all asset registered.
-        """
-
-        registered_htmls = []
-        file_type = 'html'
-
-        for lang, html in htmls.items():
-
-            metadata = self.get_metadata()
-            metadata.update({'bucket_name': self.bucket_name,
-                             'type': file_type,
-                             'version': 'html' if not xml_version else 'xml'})
-
-            # Se for versão HTML
-            if not xml_version:
-
-                # É necessário fazer o mesmo procedimento que é relizado no XML
-                # Cadastrar as medias e alterar o caminho diretamente no HTML
-
-                self._content = html
-                registered_media = self.register_media_html()
-
-                logger.info(u"O artigo com PID: %s é uma versão HTML.",
-                            self.xylose.publisher_id)
-
-                self._change_img_path(registered_media)  # change self._content
-
-                # Substitui a seta.jpg'
-                patterns = config.OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS.split(',')
-
-                arrow = config.OPAC_PROC_MEDIA_ARROW_REPLACE
-
-                for pattern_string in patterns:
-
-                    pattern = re.compile(pattern_string)
-
-                    if re.search(pattern, self._content):
-                        self._content = re.sub(pattern, arrow, self._content)
-
-                directory = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                         'templates')
-
-                html = utils.render_from_template(directory, 'article.html', {
-                                                  'html': self._content,
-                                                  'css': config.OPAC_PROC_ARTICLE_CSS_URL,
-                                                  'css_print': config.OPAC_PROC_ARTICLE_PRINT_CSS_URL
-                                                  })
-            if isinstance(html, unicode):
-                html = html.encode('utf-8')
-
-            # XML or HTML
-            ssm_asset = SSMHandler(BytesIO(html), self._get_name(lang), file_type,
-                                   metadata, self.bucket_name)
-
-            logger.info(u"Verificando se o asset existe: %s", ssm_asset.exists())
-
-            code, assets = ssm_asset.exists()
-
-            # Existe e o ativo é idêntico
-            if code == 1:
-                logger.info(u"Já existe um HML idêntico com PID: %s e coleção: %s, cadastrado!",
-                            self.xylose.publisher_id, self.xylose.collection_acronym)
-
-                registered_htmls.append({'type': file_type,
-                                         'lang': lang,
-                                         'url': assets[0]['full_absolute_url']
-                                         })
-
-            if code == 2:
-                logger.info(u"Já existe um HTML não idêntico com PID: %s e coleção: %s, cadastrado!",
-                            self.xylose.publisher_id, self.xylose.collection_acronym)
-
-                for asset in assets:
-                    ssm_asset.remove(asset['uuid'])
-
-            if code == 2 or code == 0:
-                uuid = ssm_asset.register()
-
-                logger.info(u"UUID: %s para XML/HTML do artigo com PID: %s",
-                            uuid, self.xylose.publisher_id)
-
-                registered_htmls.append({'type': file_type,
-                                         'lang': lang,
-                                         'url': ssm_asset.get_urls()['url']
-                                         })
-
-        if registered_htmls:
-            return registered_htmls
-
-    def register_from_xml(self, uuid):
-        """
-        Method to register the HTML(s) of the asset from XML version.
-
-        This method consider if not uuid: It`s a HTML version else: is a XML
-        version.
-
-        Params:
-            :param uuid: uuid do XML
-        """
-
-        ssm_handler = SSMHandler()  # asset handler "vazio"
-
-        exists, asset = ssm_handler.get_asset(uuid)
-
-        if exists:
-            generated_htmls = self.generate_htmls(BytesIO(asset['file']))
-
-            return self.add_htmls(generated_htmls)
-
-        else:
-            logger.error("XML não existente: %s", asset)
-
-    def register(self):
-        """
-        Method to register the HTML(s) of the asset from HTML version.
-        """
-        htmls = {}
-        original_html = self.xylose.original_html()
-        translated_htmls = self.xylose.translated_htmls()
-
-        if original_html:
-            htmls.update({self.xylose.original_language(): original_html})
-
-        if translated_htmls:
-            htmls.update(translated_htmls)
-
-        if htmls:
-            return self.add_htmls(htmls, False)
-        else:
-            logger.info(u"Artigo com o PID: %s, não tem HTML",
-                        self.xylose.publisher_id)

--- a/opac_proc/tests/base.py
+++ b/opac_proc/tests/base.py
@@ -12,4 +12,5 @@ class BaseTestCase(TestCase):
     def create_app(self):
         app = current_app
         app.config['TESTING'] = True
+        app.config['DEBUG'] = False
         return app

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -336,7 +336,7 @@ class TestAssets(BaseTestCase):
             ("graphic.tif", "graphic.jpg"),
             ("graphic.tiff", "graphic.jpg"),
             ("image.gif", "image.gif"),
-            ("table", "table.jpg"),
+            ("table", "table"),
             ("abc/v21n4/graphic.tif", "abc/v21n4/graphic.jpg")
         ]
         for input, expected in input_expected:
@@ -1335,7 +1335,7 @@ class TestAssetHTMLS(BaseTestCase):
         tags = [
             ('src', tag)
             for tag in parsed_html.find_all(src=True)
-            if asset_htmls._is_valid_media_file(urlsplit(tag['src']))
+            if asset_htmls._is_valid_media_url(urlsplit(tag['src']))
         ]
         tags = tags + [
             ('href', tag)

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -191,7 +191,6 @@ OPAC_PROC_RAISE_ERROR = os.environ.get('OPAC_PROC_RAISE_ERROR', 'False') == 'Tru
 OPAC_PROC_ASSETS_SOURCE_PDF_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_PDF_PATH', '/app/data/pdf')
 OPAC_PROC_ASSETS_SOURCE_XML_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_XML_PATH', '/app/data/xml')
 OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH', '/app/data/img')
-OPAC_PROC_ASSETS_SOURCE_VIDEOS_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH', '/app/data/videos')
 
 OPAC_PROC_ARTICLE_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-article.css')
 OPAC_PROC_ARTICLE_PRINT_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_PRINT_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-print.css')

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -191,6 +191,7 @@ OPAC_PROC_RAISE_ERROR = os.environ.get('OPAC_PROC_RAISE_ERROR', 'False') == 'Tru
 OPAC_PROC_ASSETS_SOURCE_PDF_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_PDF_PATH', '/app/data/pdf')
 OPAC_PROC_ASSETS_SOURCE_XML_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_XML_PATH', '/app/data/xml')
 OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH', '/app/data/img')
+OPAC_PROC_ASSETS_SOURCE_VIDEOS_PATH = os.environ.get('OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH', '/app/data/videos')
 
 OPAC_PROC_ARTICLE_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-article.css')
 OPAC_PROC_ARTICLE_PRINT_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_PRINT_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-print.css')


### PR DESCRIPTION
#### O que este PR faz?
Corrige o problema reportado no OPAC (ver [@opac#1049](https://github.com/scieloorg/opac/issues/1049)).
- Ajustes no `AssetHTMLS._normalize_media_path()`
- Refatoração do código assets.py
- Melhorias nos testes do test_assets.py
- Melhorias nos comandos docker-compose no Makefile

#### Onde a revisão deveria começar?
No arquivo `core.assets.py`, classe `AssetHTMLS`

#### Como deveria ser testado manualmente?
1. Verificar artigos versão HTML que contém HTMLs como ativo digital, como estão hoje. Ex:
  - https://new.scielo.br/article/mioc/1997.v92n4/477-481/en/
    Contém https://new.scielo.br/img/fbpe/mioc/v92n4/html/05fig1.htm, que está incorreta. A versão antiga (http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0074-02761997000400005&lng=en&nrm=iso&tlng=en) o erro não ocorre
  - https://new.scielo.br/article/acb/2002.v17n6/381-387/en/
    Contém link para http://new.scielo.br/videos/acb/v17n6/n6a05vd.htm, que está incorreta. A versão antiga (http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0102-86502002000600005&lng=en&nrm=iso&tlng=en) o erro não ocorre
2. Reprocessar os artigos na fase de transformação e de carregamento do PROC
3. Verificar se os arquivos foram corrigidos

#### Algum contexto que queira fornecer?
Os artigos em HTML, além de não processarem os ativos digitais que estavam referenciados no artigo como âncora, também não previa o processamento de ativos digitais HTML, que necessitam do processamento de ativos referenciados em seu conteúdo.

#### Quais são os tickets relevantes?
@opac#1049](https://github.com/scieloorg/opac/issues/1049)

#### Screenshots (se relevante)
N/A

####  Questões:
N/A