### PR TITLE
Correção na validação de URL na transformação de Artigo

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -215,7 +215,8 @@ class Assets(object):
         - SplitResult path extension file is in config.MEDIA_EXTENSION_FILES
           list
         """
-        if parsed_url and parsed_url.scheme and parsed_url.netloc:
+        if parsed_url and (
+                parsed_url.scheme or parsed_url.netloc or not parsed_url.path):
             return False
         return os.path.splitext(parsed_url.path)[-1] in self._ext_files_list
 

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -1185,6 +1185,31 @@ class TestAssetHTMLS(BaseTestCase):
         self.assertIsNotNone(new_media_path)
         self.assertEqual(new_media_path, expected)
 
+    def test_is_valid_media_url_invalid_url(self):
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        invalid_urls = [
+            "http://www.google.com/img.gif",
+            "https://www.server.com/img.jpg",
+            "//www.portal.com/img.tif",
+            "/img.doc",
+            "#anchor",
+        ]
+        for invalid_url in invalid_urls:
+            splited_url = urlsplit(invalid_url)
+            self.assertFalse(asset._is_valid_media_url(splited_url))
+
+    def test_is_valid_media_url_valid_url(self):
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        invalid_urls = [
+            "/img.gif",
+            "img/fbpe/img.jpg",
+            "/img/revistas/test/v1n2/img.tif",
+            "/img/revistas/test/v1n2/seta.gif#anchor",
+        ]
+        for invalid_url in invalid_urls:
+            splited_url = urlsplit(invalid_url)
+            self.assertTrue(asset._is_valid_media_url(splited_url))
+
     @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
     @patch.object(AssetHTMLS, '_normalize_media_path')
     @patch.object(AssetHTMLS, '_open_asset')


### PR DESCRIPTION
#### O que esse PR faz?
Correção de `Asset._is_valid_media_url()`

#### Onde a revisão poderia começar?
No `Asset._is_valid_media_url()` e no `TestAssetHTMLS`, nos testes para validar o método

#### Como este poderia ser testado manualmente?
Transformar um artigo em versão HTML contendo âncoras. Ex.: `S0074-02761997000500013`

#### Algum cenário de contexto que queira dar?
Foram feitas correções na transformação de artigos HTML em #385. Esse erro corrige esse PR.

#### Quais são tickets relevantes?
[@opac#1049](https://github.com/scieloorg/opac/issues/1049)

#### Screenshots (se aplicável)
N/A