### PR TITLE
 Correção na validação e normalização de URL na transformação de Artigo

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -215,7 +215,8 @@ class Assets(object):
         - SplitResult path extension file is in config.MEDIA_EXTENSION_FILES
           list
         """
-        if parsed_url and parsed_url.scheme and parsed_url.netloc:
+        if parsed_url and (
+                parsed_url.scheme or parsed_url.netloc or not parsed_url.path):
             return False
         return os.path.splitext(parsed_url.path)[-1] in self._ext_files_list
 

--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -215,8 +215,7 @@ class Assets(object):
         - SplitResult path extension file is in config.MEDIA_EXTENSION_FILES
           list
         """
-        if parsed_url and (
-                parsed_url.scheme or parsed_url.netloc or not parsed_url.path):
+        if parsed_url and (parsed_url.netloc or not parsed_url.path):
             return False
         return os.path.splitext(parsed_url.path)[-1] in self._ext_files_list
 
@@ -568,13 +567,14 @@ class AssetHTMLS(Assets):
           - img/fbpe
           - img/revistas
           must be replaced with OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
-        - ../ or ./ path start must be replaced with /
+        - ../, ./ or PDFs file path start must try to get media path
         Return normalized path
         """
         media_path = super(AssetHTMLS, self)._normalize_media_path(
             original_path)
         source_media_path = config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH
-        if re.findall(r'^\.[/|./]+', media_path):
+        if (re.findall(r'^\.[/|./]+', media_path) or
+                os.path.splitext(media_path)[-1].lower() == '.pdf'):
             media_path = self._get_media_path(os.path.basename(media_path))
         else:
             change_media_path = [('/img/fbpe', source_media_path),

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -1185,6 +1185,31 @@ class TestAssetHTMLS(BaseTestCase):
         self.assertIsNotNone(new_media_path)
         self.assertEqual(new_media_path, expected)
 
+    def test_is_valid_media_url_invalid_url(self):
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        invalid_urls = [
+            "http://www.google.com/img.gif",
+            "https://www.server.com/img.jpg",
+            "//www.portal.com/img.tif",
+            "/img.doc",
+            "#anchor",
+        ]
+        for invalid_url in invalid_urls:
+            splited_url = urlsplit(invalid_url)
+            self.assertFalse(asset._is_valid_media_url(splited_url))
+
+    def test_is_valid_media_url_valid_url(self):
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        invalid_urls = [
+            "/img.gif",
+            "img/fbpe/img.jpg",
+            "/img/revistas/test/v1n2/img.tif",
+            "/img/revistas/test/v1n2/seta.gif#anchor",
+        ]
+        for invalid_url in invalid_urls:
+            splited_url = urlsplit(invalid_url)
+            self.assertTrue(asset._is_valid_media_url(splited_url))
+
     @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
     @patch.object(AssetHTMLS, '_normalize_media_path')
     @patch.object(AssetHTMLS, '_open_asset')

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -1185,6 +1185,31 @@ class TestAssetHTMLS(BaseTestCase):
         self.assertIsNotNone(new_media_path)
         self.assertEqual(new_media_path, expected)
 
+    def test_normalize_media_path_replace_relative_path(self):
+        acronym = self.mocked_xylose_article.journal.acronym.lower()
+        issue = self.mocked_xylose_article.assets_code
+        media_path = '../asset.gif'
+        expected = '%s/%s/%s/asset.gif' % (
+            config.OPAC_PROC_ASSETS_SOURCE_MEDIA_PATH, acronym, issue)
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        new_media_path = asset._normalize_media_path(media_path)
+        self.assertIsNotNone(new_media_path)
+        self.assertEqual(new_media_path, expected)
+
+    def test_normalize_media_path_replace_to_source_pdf_path(self):
+        acronym = self.mocked_xylose_article.journal.acronym.lower()
+        issue = self.mocked_xylose_article.assets_code
+        media_path = 'pdf/%s/%s/a01.pdf' % (acronym, issue)
+        expected = '%s/%s/%s/a01.pdf' % (
+            config.OPAC_PROC_ASSETS_SOURCE_PDF_PATH, acronym, issue)
+        asset = AssetHTMLS(self.mocked_xylose_article)
+        new_media_path = asset._normalize_media_path(media_path)
+        self.assertIsNotNone(new_media_path)
+        self.assertEqual(new_media_path, expected)
+        new_media_path = asset._normalize_media_path('/' + media_path)
+        self.assertIsNotNone(new_media_path)
+        self.assertEqual(new_media_path, expected)
+
     def test_is_valid_media_url_invalid_url(self):
         asset = AssetHTMLS(self.mocked_xylose_article)
         invalid_urls = [
@@ -1203,8 +1228,11 @@ class TestAssetHTMLS(BaseTestCase):
         invalid_urls = [
             "/img.gif",
             "img/fbpe/img.jpg",
+            "http:/img/fbpe/img.tif",
+            "https:/pdf/fbpe/a01.pdf",
             "/img/revistas/test/v1n2/img.tif",
             "/img/revistas/test/v1n2/seta.gif#anchor",
+            "../img02a.avi",
         ]
         for invalid_url in invalid_urls:
             splited_url = urlsplit(invalid_url)

--- a/opac_proc/web/config.py
+++ b/opac_proc/web/config.py
@@ -196,7 +196,7 @@ OPAC_PROC_ARTICLE_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_CSS_URL', 'https:/
 OPAC_PROC_ARTICLE_PRINT_CSS_URL = os.environ.get('OPAC_PROC_ARTICLE_PRINT_CSS_URL', 'https://ssm.scielo.org/media/assets/css/scielo-print.css')
 OPAC_PROC_ARTICLE_JS_URL = os.environ.get('OPAC_PROC_ARTICLE_JS_URL', 'https://ssm.scielo.org/media/assets/js/scielo-article.js')
 
-MEDIA_EXTENSION_FILES = os.environ.get('OPAC_PROC_MEDIA_EXTENSION_FILES', 'tiff,tif,jpg,jpeg,gif,webp,png,svg,mp3,mp4,wav,wma,avi')
+MEDIA_EXTENSION_FILES = os.environ.get('OPAC_PROC_MEDIA_EXTENSION_FILES', 'tiff,tif,jpg,jpeg,gif,webp,png,svg,mp3,mp4,wav,wma,avi,pdf')
 MEDIA_EXT_LINKS_IND = os.environ.get('OPAC_PROC_MEDIA_EXT_LINKS_IND', 'http,ftp,sft,sft')
 OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS = os.environ.get('OPAC_PROC_MEDIA_ARROW_MATCH_REGEXS', '<a href="#top">(.*?)</a>,<a href="#enda">(.*?)</a>,<a href="#up">(.*?)</a>')
 OPAC_PROC_MEDIA_ARROW_REPLACE = os.environ.get('OPAC_PROC_MEDIA_ARROW_REPLACE', '<a href="#top">&#9650;</a>')


### PR DESCRIPTION
#### O que esse PR faz?
- Correção de `Asset._is_valid_media_url()` considerando URLs como `http:/img/fbpe/acronym/v1n1/file.jpg`
- Correção de `Asset._normalize_media_path()` para inclusão de PDFs como media assets
- Inclusão de `pdf` nas extensões válidas de media assets

#### Onde a revisão poderia começar?
Pelo `test_assets.py`, que tem testes para a validação das alterações

#### Como este poderia ser testado manualmente?
Transformando artigos de periódicos que contenham arquivos HTML e PDF como ativos digitais. Ex: artigos do periódico _Memórias do Instituto Oswaldo Cruz_, fascículo `v22n1`.

#### Algum cenário de contexto que queira dar?
Essa correção diz respeito ao tratamento de artigos não estruturados em XML.

#### Quais são tickets relevantes?
(@opac/1049)[/scieloorg/opac/issues/1049] e #380 

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
