### PR TITLE
Atualização da versão do mongoengine e fixação da versão do redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
 
 # COPY ./requirements.txt /app/requirements.txt
 COPY . /app
+RUN pip --no-cache-dir install --upgrade pip
 RUN pip --no-cache-dir install -r /app/requirements.txt
 
 COPY ./start_worker.sh /start_worker.sh

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -31,6 +31,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /app/requirements.txt
+RUN pip --no-cache-dir install --upgrade pip
 RUN pip --no-cache-dir install -r /app/requirements.txt
 
 COPY ./start_worker.sh /start_worker.sh

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -23,7 +23,7 @@ services:
         - /etc/localtime:/etc/localtime:ro
 
   redis:
-    image: scieloorg/redis
+    image: redis:alpine
     user: redis
     restart: always
     hostname: opac-proc-redis

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -38,7 +38,7 @@ services:
     #     - /etc/localtime:/etc/localtime:ro
 
   redis:
-    image: scieloorg/redis
+    image: redis:alpine
     user: redis
     restart: always
     hostname: opac-proc-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         - /etc/localtime:/etc/localtime:ro
 
   redis:
-    image: scieloorg/redis
+    image: redis:alpine
     user: redis
     restart: always
     hostname: opac-proc-redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 Werkzeug==0.14.1
 Flask==0.12.4
-mongoengine==0.16.1
+mongoengine==0.16.2
 flask-mongoengine==0.9.5
 thriftpy==0.3.9
+redis==2.10.6
 rq==0.12.0
 rq-dashboard==0.3.12
 rq-scheduler==0.8.3


### PR DESCRIPTION
- Atualização do mongoengine: 0.16.1 => 0.16.2
- Fixação da versão do redis por [incompatibilidade](https://github.com/rq/rq/issues/1014) da versão `0.12.0` do rq  com `redis >= 3.0`
