### PR TITLE
Alteração na extração de dados de coleção

### DIFF
--- a/opac_proc/extractors/ex_collections.py
+++ b/opac_proc/extractors/ex_collections.py
@@ -89,12 +89,7 @@ class CollectionExtractor(BaseExtractor):
         logger.info(u'Inicia CollectionExtractor.extract(%s) %s' % (
             self.acronym, datetime.now()))
 
-        for col in self.articlemeta.get_collections():
-            if col['acronym'] == self.acronym:
-                logger.info(u"Adicionado a coleção: %s" % self.acronym)
-                self._raw_data = col
-                break
-
+        self._raw_data = self.articlemeta.get_collection(code=self.acronym)
         if not self._raw_data:
             msg = u"Não foi possível recuperar a Coleção (acronym: %s). A informação é vazía" % self.acronym
             logger.error(msg)

--- a/opac_proc/extractors/source_clients/amapi_wrapper/custom_amapi_client.py
+++ b/opac_proc/extractors/source_clients/amapi_wrapper/custom_amapi_client.py
@@ -153,6 +153,15 @@ class ArticleMeta(object):
             collection=collection, issn=issn,
             from_date=from_date, until_date=until_date)
 
+    def get_collection(self, code):
+        """
+        methods to get one single COLLECTION as dict()
+        @params:
+        - code: collection code ('spa', 'scl', etc)
+        """
+        collection = self.client.collection(code=code)
+        return collection.__dict__
+
     def get_journal(self, code, collection):
         """
         methods to get one single JOURNAL as dict()


### PR DESCRIPTION
#### O que esse PR faz?
Altera a extração de coleção para, ao invés de recuperar todos os dados de coleção do AM para procurar uma na lista, recupera a coleção dada.

#### Onde a revisão poderia começar?
Pelo `ex_collections.py`, onde é feito um _for loop_ para obter uma coleção da lista retornada.

#### Como este poderia ser testado manualmente?
O seguinte job deve funcionar:
```
from opac_proc.extractors.jobs import task_extract_one_collection
task_extract_one_collection()
```
Pela interface, extrair a coleção no processo de ETL tbm deve funcionar.

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
Related to scieloorg/articles_meta/issues/155

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
