### PR TITLE
Retiradas tarefas de diff de deleção de registros de artigos

### DIFF
--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -548,16 +548,16 @@ def clear_idsync_scheduler(model_name='all'):
 
 
 @manager.command
-@manager.option('-s', '--stage', dest='stage')
-@manager.option('-m', '--model', dest='model_name')
-@manager.option('-a', '--action', dest='action')
-def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
+def setup_produce_delete_article_differs():
     """
-    instala os schedulers para producir a diferencia nos modelos de ETL.
-    Por padrão aplica para todas as fases, todos os modelos e todas as açoes
+    Configura os schedulers para produzir a diferença de deleção nos modelos de ETL
+    SOMENTE para artigos.
+    Caso necessite aplicar para os demais modelos e operações, utilizar o comando
+    setup_produce_differ_scheduler().
     """
     stages_list, models_list, actions_list = clean_differ_scheduler_params(
-        stage, model_name, action)
+        'all', 'article', 'delete')
+
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:
@@ -566,6 +566,34 @@ def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
                 print "[%s][%s][%s] instalando scheduler na fila: %s" % (
                     stage_, model_, action_, sched_instance.queue_name)
                 sched_instance.setup()
+
+
+@manager.command
+@manager.option('-s', '--stage', dest='stage')
+@manager.option('-m', '--model', dest='model_name')
+@manager.option('-a', '--action', dest='action')
+def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
+    """
+    instala os schedulers para produzir a diferença nos modelos de ETL.
+    Por padrão aplica para todas as fases, todos os modelos e todas as açoes, EXCETO
+    para artigo.
+    Caso necessite aplicar para artigo, utilizar o comando manual
+    setup_produce_delete_article_differs().
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        stage, model_name, action)
+
+    print "ESTE PROCESSO NÃO CRIA TAREFAS DE DELEÇÃO DE REGISTROS DE ARTIGO!"
+    "UTILIZE O COMANDO setup_produce_delete_article_differs"
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                if not (model_ == 'article' and action_ == 'delete'):
+                    sched_class = PRODUCER_SCHEDS[stage_][model_][action_]
+                    sched_instance = sched_class()
+                    print "[%s][%s][%s] instalando scheduler na fila: %s" % (
+                        stage_, model_, action_, sched_instance.queue_name)
+                    sched_instance.setup()
 
 
 @manager.command


### PR DESCRIPTION
#### O que esse PR faz?
- Alterado comando `setup_produce_differ_scheduler` no `manage.py` para
não enfileirar tarefas de diff produce para deleção de registros de artigos
- Criado comando `setup_produce_delete_article_differs` no `manage.py`
para enfileirar exclusivamente tarefas de diff produce de registros de
artigos, incluindo tarefas de deleção

#### Onde a revisão poderia começar?
Em `opac_proc/manage.py`, no comando `setup_produce_differ_scheduler`

#### Como este poderia ser testado manualmente?
- Executar o comando `python opac_proc/manage.py setup_produce_differ_scheduler`. Ele deve configurar todas as filas de produce no scheduler, exceto as filas de deleção de registros de artigos em todas as fases do ETL
- Executar o comando `python opac_proc/manage.py setup_produce_delete_article_differs`.  Ele deve configurar somente as filas de produce de deleção de registros de artigos no scheduler.

#### Algum cenário de contexto que queira dar?
As tarefas de deleção de registros de artigos estavam deletando os ex-AOPs e, com isso, não é possível encontrá-los utilizando as referências (`url_segment`) antigas. Para que os dados sejam tratados antes de serem deletados, a primeira medida emergencial é retirar os processos automáticos de exclusão e um posterior tratamento para que os dados não fiquem duplicados no OPAC.

#### Quais são tickets relevantes?
#416 

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
