### PR TITLE
Retira data de corte para issues

### DIFF
--- a/opac_proc/extractors/source_clients/am_db/api_db_adapter.py
+++ b/opac_proc/extractors/source_clients/am_db/api_db_adapter.py
@@ -116,13 +116,10 @@ class AMDBAPI:
         docs = [doc for doc in results]
         return docs
 
-    def get_issues_identifiers(self, since_date=None):
+    def get_issues_identifiers(self):
         """
         retorna os identifiers de issues filtrando pela coleção definida
         pela configuração e a data de corte.
-
-        @param: since_date (datetime|opcional) - data de corte. se não for
-        definida será usada a data retornada pela property: get_since_date
 
         returna uma lista de dict()
         cada dict contém:
@@ -131,14 +128,8 @@ class AMDBAPI:
         - processing_date: retornada pelo AM
         """
 
-        if since_date is None:
-            since_date = self._since_date
-
         query_filter = {
             'collection': OPAC_PROC_COLLECTION,
-            'processing_date': {
-                '$gte': since_date,
-            }
         }
         projection = self._projection_by_model['issue']
         results = self._db.issues.find(query_filter, projection)


### PR DESCRIPTION
#### O que esse PR faz?
Retira a data de corte para recuperar os identificadores de periódicos.
Como o `processing_date` do periódico é reference ao cadastro na Title e este pode ocorrer meses antes da entrada dele para ingestão, o OPAC-PROC não consegue recuperá-lo e isso acaba gerando erro no processamento de artigos relacionados a ele.

#### Como este poderia ser testado manualmente?
Pela interface WEB, acessar os Identifiers > Issues > Processar > Todos os registros.
Deve ser possível recuperar os identificadores de todos os periódicos, independente do campo `processing_date`.

#### Algum cenário de contexto que queira dar?
Como informação complementar, ocorre no processamento de artigos relacionados aos periódicos não processados a seguinte exceção:

`DoesNotExist: TransformIssue matching query does not exist.`

#### Quais são tickets relevantes?
N/A
