### PR TITLE
Corrige normalização de paths dos assets sem extensão de arquivo

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -231,7 +231,7 @@ class Assets(object):
             else:
                 if guessed_ext == 'jpeg':
                     guessed_ext = 'jpg'
-                ext = '.' + guessed_ext
+            ext = '.' + guessed_ext
         return root + ext
 
     def _register_ssm_media(self, pfile, media_path, file_type, metadata):

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -336,7 +336,7 @@ class TestAssets(BaseTestCase):
             ("graphic.tif", "graphic.jpg"),
             ("graphic.tiff", "graphic.jpg"),
             ("image.gif", "image.gif"),
-            ("table", "table"),
+            ("table", "table.jpg"),
             ("abc/v21n4/graphic.tif", "abc/v21n4/graphic.jpg")
         ]
         for input, expected in input_expected:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o método `Assets. _normalize_media_path()` para, quando o arquivo estiver sem extensão, fazer a introspecção para `.jpg`

#### Como este poderia ser testado manualmente?
Transformar um artigo XML que contenha ativo digital sem extensão. Ele deve ser transformado com sucesso e o ativo digital deve seguir o fluxo normal com a extensão `.jpg`.

#### Algum cenário de contexto que queira dar?
N/A