### PR TITLE
Retiradas tarefas de diff de deleção de registros de fascículos

### DIFF
--- a/opac_proc/manage.py
+++ b/opac_proc/manage.py
@@ -569,6 +569,27 @@ def setup_produce_delete_article_differs():
 
 
 @manager.command
+def setup_produce_delete_issue_differs():
+    """
+    Configura os schedulers para produzir a diferença de deleção nos modelos de ETL
+    SOMENTE para fascículos.
+    Caso necessite aplicar para os demais modelos e operações, utilizar o comando
+    setup_produce_differ_scheduler().
+    """
+    stages_list, models_list, actions_list = clean_differ_scheduler_params(
+        'all', 'issue', 'delete')
+
+    for stage_ in stages_list:
+        for model_ in models_list:
+            for action_ in actions_list:
+                sched_class = PRODUCER_SCHEDS[stage_][model_][action_]
+                sched_instance = sched_class()
+                print "[%s][%s][%s] instalando scheduler na fila: %s" % (
+                    stage_, model_, action_, sched_instance.queue_name)
+                sched_instance.setup()
+
+
+@manager.command
 @manager.option('-s', '--stage', dest='stage')
 @manager.option('-m', '--model', dest='model_name')
 @manager.option('-a', '--action', dest='action')
@@ -583,12 +604,12 @@ def setup_produce_differ_scheduler(stage='all', model_name='all', action='all'):
     stages_list, models_list, actions_list = clean_differ_scheduler_params(
         stage, model_name, action)
 
-    print "ESTE PROCESSO NÃO CRIA TAREFAS DE DELEÇÃO DE REGISTROS DE ARTIGO!"
-    "UTILIZE O COMANDO setup_produce_delete_article_differs"
+    print "ESTE PROCESSO NÃO CRIA TAREFAS DE DELEÇÃO DE REGISTROS DE FASCÍCULO E ARTIGO!"
+    "UTILIZE O COMANDO setup_produce_delete_article_differs e setup_produce_delete_issue_differs"
     for stage_ in stages_list:
         for model_ in models_list:
             for action_ in actions_list:
-                if not (model_ == 'article' and action_ == 'delete'):
+                if not ((model_ == 'article' or model_ == 'issue') and action_ == 'delete'):
                     sched_class = PRODUCER_SCHEDS[stage_][model_][action_]
                     sched_instance = sched_class()
                     print "[%s][%s][%s] instalando scheduler na fila: %s" % (


### PR DESCRIPTION
#### O que esse PR faz?
- Alterado comando `setup_produce_differ_scheduler` no `manage.py` para
não enfileirar tarefas de diff produce para deleção de registros de
fascículos
- Criado comando `setup_produce_delete_issue_differs` no `manage.py`
para enfileirar exclusivamente tarefas de diff produce de registros de
deleção de fascículos

#### Onde a revisão poderia começar?
Em `opac_proc/manage.py`, no comando `setup_produce_differ_scheduler`

#### Como este poderia ser testado manualmente?
- Executar o comando `python opac_proc/manage.py setup_produce_differ_scheduler`. Ele deve configurar todas as filas de produce no scheduler, exceto as filas de deleção de registros de fascículos e artigos em todas as fases do ETL
- Executar o comando `python opac_proc/manage.py setup_produce_delete_issue_differs`.  Ele deve configurar somente as filas de produce de deleção de registros de fascículos no scheduler.

#### Algum cenário de contexto que queira dar?
As tarefas de deleção de registros de fascículos estavam deletando os ex-AOPs e, com isso, não é possível encontrá-los utilizando as referências (`url_segment`) antigas. Para que os dados sejam tratados antes de serem deletados, a primeira medida emergencial é retirar os processos automáticos de exclusão e um posterior tratamento para que os dados não permaneçam no OPAC.

#### Quais são tickets relevantes?
#416 

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A