### PR TITLE
Atualização do opac-schema para adicionar o novo campo 'new_title' no…

### DIFF
--- a/opac_proc/loaders/lo_journals.py
+++ b/opac_proc/loaders/lo_journals.py
@@ -52,6 +52,7 @@ class JournalLoader(BaseLoader):
         'social_networks',
         'title',
         'title_iso',
+        'next_title',
         'short_title',
         'title_slug',
         'created',

--- a/opac_proc/transformers/tr_journals.py
+++ b/opac_proc/transformers/tr_journals.py
@@ -114,6 +114,10 @@ class JournalTransformer(BaseTransformer):
         if hasattr(xylose_journal, 'abbreviated_iso_title'):
             self.transform_model_instance['title_iso'] = xylose_journal.abbreviated_iso_title
 
+        # next_title
+        if hasattr(xylose_journal, 'next_title'):
+            self.transform_model_instance['next_title'] = xylose_journal.next_title
+
         # mission
         if hasattr(xylose_journal, 'mission'):
             missions = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ blinker==1.4
 mongolog==0.1.1
 xylose==1.35.0
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.48#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.49#egg=opac_schema
 scieloh5m5==1.11.0
 requests==2.21.0
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
#### O que esse PR faz?
Atualização do opac-schema para adicionar o novo campo `new_title` no model `Journal`.
esse campo foi adicionado a transformação e ao load do journal, pois ele será necessário para a exibição dos periódicos descontinuados, na lista de periódicos do OPAC 

#### Onde a revisão poderia começar?
comece a revisão pelo `tr_journals.py` na leitura dos dados pelo xylose 

#### Como este poderia ser testado manualmente?
transforme e carregue periódicos descontinuados e que tenham mudança de titulo

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1117
