### PR TITLE
Corrige campo 'is_aop' que informava o ex-ahead ao invés do ahead

### DIFF
--- a/opac_proc/transformers/tr_articles.py
+++ b/opac_proc/transformers/tr_articles.py
@@ -114,9 +114,12 @@ class ArticleTransformer(BaseTransformer):
             self.transform_model_instance['doi'] = xylose_article.doi
 
         # is_aop
+        if xylose_article.issue.is_ahead_of_print:
+            self.transform_model_instance['is_aop'] = True
+
+        # is_ex_aop
         if hasattr(xylose_article, 'publisher_ahead_id'):
             if xylose_article.publisher_ahead_id:
-                self.transform_model_instance['is_aop'] = True
                 self.transform_model_instance['aop_pid'] = xylose_article.publisher_ahead_id
 
         # created


### PR DESCRIPTION
#### O que esse PR faz?
Corrige campo `is_aop` do artigo na fase de transformação, que estava sendo informado como verdadeiro nos artigos ex-ahead ao invés dos aheads atuais.

#### Onde a revisão poderia começar?
Em `transformers/tr_article.py`, `ArticleTransformer.transform()` nos sets de parâmetros do Xylose.

#### Como este poderia ser testado manualmente?
Ao transformar um artigo Ahead of Print, o campo `is_aop` deve ser True. Para os ex-aheads, este campo não deve existir. O que indica que ele é um ex-ahead é o campo `aop_pid`.

#### Algum cenário de contexto que queira dar?
No admin do site, no catálogo de artigos, o filtro de "É Ahead of Print?" retorna os ex-aheads ao invés dos aheads.

#### Quais são tickets relevantes?
#418 

#### Screenshots (se aplicável)
N/A

#### Referências:
N/A
