### PR TITLE
[opac] Erro ao popular dados de study_areas e subject_categories

### DIFF
--- a/opac_proc/transformers/tr_journals.py
+++ b/opac_proc/transformers/tr_journals.py
@@ -53,12 +53,12 @@ class JournalTransformer(BaseTransformer):
         self.transform_model_instance['collection'] = transform_col.uuid
 
         # subject_categories
-        if hasattr(xylose_journal, 'subject_areas'):
-            self.transform_model_instance['subject_categories'] = xylose_journal.subject_areas
+        if hasattr(xylose_journal, 'wos_subject_areas'):
+            self.transform_model_instance['subject_categories'] = xylose_journal.wos_subject_areas
 
         # study_areas
-        if hasattr(xylose_journal, 'wos_subject_areas'):
-            self.transform_model_instance['study_areas'] = xylose_journal.wos_subject_areas
+        if hasattr(xylose_journal, 'subject_areas'):
+            self.transform_model_instance['study_areas'] = xylose_journal.subject_areas
 
         # current_status
         if hasattr(xylose_journal, 'current_status'):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige erro ao popular dados de study_areas e subject_categories. Os valores estão trocados.

#### Onde a revisão poderia começar?
opac_proc/transformers/tr_journals.py

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="535" alt="captura de tela 2019-02-15 as 14 59 14" src="https://user-images.githubusercontent.com/505143/52871908-4824ae00-3132-11e9-8465-538c51712287.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1201

### Referências
N/A

