### PR TITLE
Resolve duplicidade de AOPs e acesso aos ex-AOPs pela url de AOP

### DIFF
--- a/opac_proc/loaders/jobs.py
+++ b/opac_proc/loaders/jobs.py
@@ -331,6 +331,7 @@ def task_load_one_article(uuid):
     a_loader = ArticleLoader(uuid)
     a_loader.prepare()
     a_loader.load()
+    a_loader.remove_aop_records()
 
 
 def task_load_selected_articles(selected_uuids):

--- a/opac_proc/web/views/load/list_views.py
+++ b/opac_proc/web/views/load/list_views.py
@@ -311,7 +311,7 @@ class LoadArticleListView(LoadBaseListView):
         },
         {
             'field_label': u'PID',
-            'field_name': 'loaded_data.pid',
+            'field_name': 'loaded_data__pid',
             'field_type': 'string'
         },
         {
@@ -321,12 +321,12 @@ class LoadArticleListView(LoadBaseListView):
         },
         {
             'field_label': u'Process completed?',
-            'field_name': 'metadata.process_completed',
+            'field_name': 'metadata__process_completed',
             'field_type': 'boolean'
         },
         {
             'field_label': u'Reprocess?',
-            'field_name': 'metadata.must_reprocess',
+            'field_name': 'metadata__must_reprocess',
             'field_type': 'boolean'
         },
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ blinker==1.4
 mongolog==0.1.1
 xylose==1.35.0
 legendarium==2.0.2
--e git+https://git@github.com/scieloorg/opac_schema@v2.49#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
 scieloh5m5==1.11.0
 requests==2.21.0
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
#### O que esse PR faz?
Ele resolve o problema da duplicidade de Ahead Of Print. Com a entrada de um ex-ahead em um fascículo regular, é necessário que a URL do AOP continue funcionando. Os url_segments do "issue" de ahead e do Ahead Of Print são usados na montagem da URL para o artigo e este PR grava esses dados no registro de ex-ahead. Para que o não haja duplicidade, o identifier e os registros de ETL são excluídos. Em detalhes, este PR:

- Atualiza o OPAC-SCHEMA para adicionar o campo de `aop_url_segs`, onde os url_segments do "issue" de ahead e do artigo AOP são mantidos
- Criado `ArticleLoader.prepare_aop_url_segs()` para a montagem do conteúdo do campo `aop_url_segs`
- Criado `ArticleLoader.remove_aop_records()` para a exclusão do identifier e sos registros de ETL do AOP
- Correção do filtro de PID na list_view do load.

#### Onde a revisão poderia começar?
Em `opac_proc/loaders/lo_articles.py`, na class `ArticleLoader`

#### Como este poderia ser testado manualmente?
Efetue o load um ex-ahead que tenha registro seu registro de AOP no PROC. O comportamento esperado:
- O registro de LoadArticle deve conter campo `loaded_data.aop_url_segs` com os url_segments do ahead
- O registro de OpacArticle deve conter o campo aop_url_segs com os dados acima
- Os registros de identifier e ETL do AOP não devem existir

#### Algum cenário de contexto que queira dar?
Essa duplicidade está incorreta, pois o artigo não deve estar como ex-ahead e ahead simultaneamente.
Lembrete: nem todos os ex-aheads tem AOPs registrados no OPAC-PROC.

### Screenshots
N/A

#### Quais são tickets relevantes?
#409 e scieloorg/opac/issues/937

### Referências
Nenhuma.
