### PR TITLE
Processa URL da imagem de feeds do Blog SciELO

### DIFF
--- a/opac_proc/loaders/lo_news.py
+++ b/opac_proc/loaders/lo_news.py
@@ -41,4 +41,5 @@ class NewsLoader(BaseLoader):
         'title',
         'description',
         'language',
+        'image_url',
     ]

--- a/opac_proc/transformers/tr_news.py
+++ b/opac_proc/transformers/tr_news.py
@@ -48,6 +48,7 @@ class NewsTransformer(BaseTransformer):
         title -> self.extract_model_instance['title']
         description -> self.extract_model_instance['summary']
         language -> self.extract_model_instance['feed_lang']
+        image_url -> self.extract_model_instance['media_content'][0]['url']
         """
 
         # UUID:
@@ -67,5 +68,11 @@ class NewsTransformer(BaseTransformer):
 
         # LANGUAGE:
         self.transform_model_instance['language'] = self.extract_model_instance.feed_lang
+
+        # MEDIA CONTENT:
+        if hasattr(self.extract_model_instance, 'media_content'):
+            media_content = self.extract_model_instance.media_content
+            if len(media_content) > 0 and media_content[0].get('url'):
+                self.transform_model_instance['image_url'] = media_content[0]['url']
 
         return self.transform_model_instance


### PR DESCRIPTION
#### O que esse PR faz?
A URL da imagem de feeds do Blog SciELO já estavam sendo salvas na extração mas não enviadas para o site. Atualiza a base do OPAC para que essa URL esteja disponível.

#### Onde a revisão poderia começar?
Em `opac_proc/transformers/tr_news.py`, no método `transform()`

#### Como este poderia ser testado manualmente?
Transformar e carregar todas as `News`. A URL vinda do feed em `media_content` deve estar nos registros de `News` do OPAC.

#### Algum cenário de contexto que queira dar?
Para exibição das imagens dos feeds do Blog SciELO é necessário que a base do OPAC seja alimentada com os dados processados pelo PROC. Também é necessária alteração do OPAC para a imagem ser exibida.

### Screenshots
N/A.

#### Quais são tickets relevantes?
scieloorg/opac/issues/318

### Referências
Nenhuma.


