### PR TITLE
adiconando versão do redis no requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ Flask-Mail==0.9.1
 articlemetaapi==1.26.2
 beautifulsoup4==4.6.3
 mock==2.0.0
+redis==2.10.6


### PR DESCRIPTION
#### O que esse PR faz?
Adicionando Versão da lib do redis usada pelo rq para a versao `redis==2.10.6`

#### Algum cenário de contexto que queira dar?
o problema acontece com a versão mais nova da lib

