### PR TITLE
Atualizacao da verção do packtools scieloorg/opac#1123

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ gunicorn==19.8.1
 gevent==1.3.7
 itsdangerous==1.1.0
 python-slugify==1.2.6
-packtools==2.4.1
+packtools==2.4.2
 -e git+https://github.com/scieloorg/opac_ssm_api@v2.0.1#egg=opac_ssm_api
 raven[flask]==6.9.0
 Flask-Testing==0.7.1


### PR DESCRIPTION
#### O que esse PR faz?
esse PR atualiza a versao do packtools para incorporar as novas alteração do XSLT
https://github.com/scieloorg/packtools/commit/3524cfbefb8e6d676c3448f24b47fdf92163b85e
 

#### Onde a revisão poderia começar?
pelo `requirements.txt`

#### Como este poderia ser testado manualmente?
apos atualizar o codigo e reconstruir a docker ou seu ambiente local, rodas os teste ou reprocessar alguns documentos atraves da interface web do opac

#### Quais são tickets relevantes?
scieloorg/opac#1123