### PR TITLE
Corrige a carga de periódicos sem fascículos para o site

### DIFF
--- a/opac_proc/web/views/load/list_views.py
+++ b/opac_proc/web/views/load/list_views.py
@@ -108,7 +108,7 @@ class LoadJournalListView(LoadBaseListView):
             'field_type': 'string'
         },
         {
-            'field_label': u'Aconym',
+            'field_label': u'Acronym',
             'field_name': 'loaded_data.acronym',
             'field_type': 'string'
         },
@@ -146,18 +146,18 @@ class LoadJournalListView(LoadBaseListView):
             'field_type': 'uuid'
         },
         {
-            'field_label': u'Aconym',
-            'field_name': 'loaded_data.acronym',
+            'field_label': u'Acronym',
+            'field_name': 'loaded_data__acronym',
             'field_type': 'string'
         },
         {
             'field_label': u'Print ISSN',
-            'field_name': 'loaded_data.print_issn',
+            'field_name': 'loaded_data__print_issn',
             'field_type': 'string'
         },
         {
             'field_label': u'SciELO ISSN',
-            'field_name': 'loaded_data.scielo_issn',
+            'field_name': 'loaded_data__scielo_issn',
             'field_type': 'string'
         },
         {
@@ -238,18 +238,23 @@ class LoadIssueListView(LoadBaseListView):
             'field_type': 'uuid'
         },
         {
-            'field_label': u'Aconym',
-            'field_name': 'loaded_data.acronym',
+            'field_label': u'PID',
+            'field_name': 'loaded_data__pid',
             'field_type': 'string'
         },
         {
-            'field_label': u'Print ISSN',
-            'field_name': 'loaded_data.print_issn',
+            'field_label': u'Volume',
+            'field_name': 'loaded_data__volume',
             'field_type': 'string'
         },
         {
-            'field_label': u'SciELO ISSN',
-            'field_name': 'loaded_data.scielo_issn',
+            'field_label': u'Number',
+            'field_name': 'loaded_data__number',
+            'field_type': 'string'
+        },
+        {
+            'field_label': u'Type',
+            'field_name': 'loaded_data__type',
             'field_type': 'string'
         },
         {


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a carga de periódicos sem fascículos para o site. As seguintes alterações foram feitas:
- Ocorria uma exceção caso o periódico não tivesse nenhum fascículo vinculado a ele. Com isso, o periódico não era carregado no site. A correção permite a carga desses periódicos para o site.
- Configura o periódico para não-público quando não houver fascículos. Assim, ele não aparece na página mas permite, por exemplo, cadastrar páginas secundárias para o periódico.
- O parâmetro `is_public` configurado no Admin do site não é sobrescrito.

Também há uma correção no filtro da listagem de periódicos carregados (Load).

#### Onde a revisão poderia começar?
Em `opac_proc/loaders/lo_journals.py`, nos métodos `prepare_collection()` e `prepare_is_public()` de `JournalLoader `

#### Como este poderia ser testado manualmente?
- Pela interface do PROC, carregar um periódico sem fascículos. O periódico deve ser carregado para a base do OPAC e deve estar com `is_public` falso.
- Pelo Admin do OPAC, alterar o `is_public` para verdadeiro. Ao carregar o periódico no PROC este deve ser preservado.

#### Algum cenário de contexto que queira dar?
Detalhes do problema no ticket scieloorg/opac/issues/1272.

### Screenshots
N/A.

#### Quais são tickets relevantes?
scieloorg/opac/issues/1272

### Referências
Nenhuma.

