### PR TITLE
Retira geração de HTML na transformação

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -510,52 +510,6 @@ class AssetXML(Assets):
                                                    self.get_metadata())
             return xml_url
 
-    def register_htmls(self):
-        """
-        Register HTML contents from XML for all the text languages.
-        """
-        try:
-            generator = HTMLGenerator.parse(
-                self._content,
-                valid_only=False,
-                css=config.OPAC_PROC_ARTICLE_CSS_URL,
-                print_css=config.OPAC_PROC_ARTICLE_PRINT_CSS_URL,
-                js=config.OPAC_PROC_ARTICLE_JS_URL
-            )
-        except ValueError as e:
-            logger.error('Error getting htmlgenerator: {}.'.format(e.message))
-            return None
-
-        registered_htmls = []
-        for lang, trans_result in generator:
-            html_as_bytes = None
-            try:
-                html = etree.tostring(trans_result, pretty_print=True,
-                                      encoding='utf-8', method='html',
-                                      doctype="<!DOCTYPE html>")
-                html_as_bytes = BytesIO(html)
-            except Exception as e:
-                logger.error(
-                    'Error converting etree {} to string. '.format(lang))
-            else:
-                metadata = self.get_metadata()
-                metadata.update({'bucket_name': self.bucket_name,
-                                 'type': 'html',
-                                 'version': 'xml'})
-                __, html_url = self._register_ssm_asset(
-                    html_as_bytes,
-                    self._get_file_name('html', lang),
-                    'html',
-                    metadata
-                )
-                registered_htmls.append({
-                    'type': 'html',
-                    'lang': lang,
-                    'url': html_url
-                })
-
-        return registered_htmls
-
 
 class AssetHTMLS(Assets):
 

--- a/opac_proc/tests/test_assets.py
+++ b/opac_proc/tests/test_assets.py
@@ -692,98 +692,6 @@ class TestAssets(BaseTestCase):
             etree.tostring(asset_xml._content.getroottree(), xml_declaration=True, encoding='utf-8')
         )
 
-    @patch('opac_proc.core.assets.HTMLGenerator.parse')
-    @patch.object(AssetXML, '_get_content')
-    def test_register_htmls_calls_packtools_html_generator_parse(
-        self,
-        mocked_get_content,
-        mocked_html_generator_parse
-    ):
-        mocked_get_content.return_value = self.xml_content
-        asset_xml = AssetXML(self.mocked_xylose_article)
-        asset_xml.register_htmls()
-        mocked_html_generator_parse.assert_called_once_with(
-            self.xml_content,
-            valid_only=False,
-            css=config.OPAC_PROC_ARTICLE_CSS_URL,
-            print_css=config.OPAC_PROC_ARTICLE_PRINT_CSS_URL,
-            js=config.OPAC_PROC_ARTICLE_JS_URL
-        )
-
-    @patch('opac_proc.core.assets.HTMLGenerator.parse')
-    @patch('opac_proc.core.assets.logger.error')
-    @patch.object(AssetXML, '_get_content')
-    def test_register_htmls_log_error_if_packtools_html_generator_error(
-        self,
-        mocked_get_content,
-        mocked_logger_error,
-        mocked_html_generator_parse
-    ):
-        mocked_get_content.return_value = self.xml_content
-        mocked_html_generator_parse.side_effect = ValueError('invalid XML')
-        asset_xml = AssetXML(self.mocked_xylose_article)
-        asset_xml.register_htmls()
-        mocked_logger_error.assert_called_once_with(
-            'Error getting htmlgenerator: invalid XML.')
-
-    @patch('opac_proc.core.assets.etree.tostring')
-    @patch('opac_proc.core.assets.logger.error')
-    @patch.object(AssetXML, '_get_path')
-    def test_register_htmls_error_if_etree_tostring_error(
-        self,
-        mocked_get_path,
-        mocked_logger_error,
-        mocked_etree_tostring
-    ):
-        mocked_get_path.return_value = self._article_xml
-        mocked_etree_tostring.side_effect = Exception()
-        # Article in 'es' translated to 'en'
-        article_json = json.loads(self._article_json)
-        document = Article(article_json)
-        asset_xml = AssetXML(document)
-        asset_xml.register_htmls()
-        logger_calls = [
-            call('Error converting etree {} to string. '.format(lang))
-            for lang in ('es', 'en')
-        ]
-        self.assertEqual(
-            mocked_logger_error.mock_calls,
-            logger_calls
-        )
-
-    @patch('opac_proc.core.assets.logger.error')
-    @patch.object(AssetXML, '_get_path')
-    @patch.object(AssetXML, '_register_ssm_asset')
-    def test_register_htmls_error_if_register_ssm_error(
-        self,
-        mocked_register_ssm_asset,
-        mocked_get_path,
-        mocked_logger_error
-    ):
-        mocked_get_path.return_value = self._article_xml
-        mocked_register_ssm_asset.side_effect = Exception()
-        # Article in 'es' translated to 'en'
-        article_json = json.loads(self._article_json)
-        document = Article(article_json)
-        asset_xml = AssetXML(document)
-        with self.assertRaises(Exception):
-            asset_xml.register_htmls()
-
-    @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
-    @patch.object(AssetXML, '_get_path')
-    def test_register_htmls_generates_translated_htmls(self, mocked_get_path):
-        # Article in 'es' translated to 'en'
-        mocked_get_path.return_value = self._article_xml
-        article_json = json.loads(self._article_json)
-        document = Article(article_json)
-        asset_xml = AssetXML(document)
-        generated_htmls = asset_xml.register_htmls()
-        self.assertEqual(len(generated_htmls), 2)
-        self.assertEqual(generated_htmls[0]['type'], 'html')
-        self.assertEqual(generated_htmls[0]['lang'], 'es')
-        self.assertEqual(generated_htmls[1]['type'], 'html')
-        self.assertEqual(generated_htmls[1]['lang'], 'en')
-
     @patch.object(AssetXML, '_get_path')
     @patch.object(AssetXML, '_get_content')
     def test_register_returns_none_if_no_content(
@@ -796,7 +704,6 @@ class TestAssets(BaseTestCase):
         xml_url = asset_xml.register()
         self.assertIsNone(xml_url)
 
-    @skip("LOCAL TEST ONLY")
     @patch('opac_proc.core.assets.SSMHandler', new=SSMHandlerStub)
     @patch.object(AssetXML, '_get_path')
     def test_register_success(self, mocked_get_path):
@@ -806,11 +713,6 @@ class TestAssets(BaseTestCase):
         asset_xml = AssetXML(document)
         xml_url = asset_xml.register()
         self.assertIsNotNone(xml_url)
-        generated_htmls = asset_xml.register_htmls()
-        self.assertEqual(generated_htmls[0]['type'], 'html')
-        self.assertEqual(generated_htmls[0]['lang'], 'es')
-        self.assertEqual(generated_htmls[1]['type'], 'html')
-        self.assertEqual(generated_htmls[1]['lang'], 'en')
 
 
 class TestAssetHTMLS(BaseTestCase):

--- a/opac_proc/transformers/tr_articles.py
+++ b/opac_proc/transformers/tr_articles.py
@@ -183,7 +183,6 @@ class ArticleTransformer(BaseTransformer):
             xml_url = asset_xml.register()
             if xml_url:
                 self.transform_model_instance['xml'] = xml_url
-                self.transform_model_instance['htmls'] = asset_xml.register_htmls()
 
         # Versão HTML do artigo
         if hasattr(xylose_article, 'data_model_version') and xylose_article.data_model_version != 'xml':


### PR DESCRIPTION
#### O que esse PR faz?
Retira a geração de HTML de artigos XML, bem como o registro das informações desse resultado. Além disso, toda a lógica que implementa a manutenção do conteúdo HTML no SSM passa a ser desnecessária e, por isso, também foi retirada. Por fim, os testes relacionados também foram removidos.
Com este PR, espera-se que a transformação de artigos passe a levar menos tempo e que recursos em disco não sejam desperdiçados sem razão.

#### Onde a revisão poderia começar?
Em `opac_proc/transformers/tr_articles.py`.

#### Como este poderia ser testado manualmente?
Para novos artigos XML:
1. Transformar um artigo
2. Não devem constar erros no Dashboard das tarefas
3. O documento na collection `t_article` não deve conter o campo `htmls`
4. O XML do artigo e seus ativos digitais devem ser encontrados no SSM mas o HTML não

Para artigos já existentes:
1. Transformar um artigo
2. Não devem constar erros no Dashboard das tarefas
3. O documento na collection `t_article` permanecem como estavam
4. O estado no SSM deve permanecer como antes da transformação (a retirada do código não remove o conteúdo do SSM)

#### Algum cenário de contexto que queira dar?
Foi implementada a renderização dos HTMLs no projeto do OPAC, tornando-se desnecessária no PROC. Mais informações em scieloorg/opac/issues/1290

### Screenshots
N/A

#### Quais são tickets relevantes?
#466.

### Referências
Nenhuma.
