### PR TITLE
Atualiza versão do Legendarium p/ correção de volumes alfanuméricos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ rq-scheduler-dashboard==0.0.2
 blinker==1.4
 mongolog==0.1.1
 xylose==1.35.0
-legendarium==2.0.2
+-e git+https://git@github.com/scieloorg/legendarium@2.0.4#egg=legendarium
 -e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
 scieloh5m5==1.11.0
 requests==2.21.0


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza versão do Legendarium que corrige a url segment de fascículos com volume alfanumérico.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
1. Acesse __Load > Issue__ na interface WEB do PROC
2. Procure um fascículo com volume alfanumérico. Ex: PID `1516-891320010005` na coleção BR
3. Selecione o fascículo e reprocesse-o.
4. Certifique-se que nenhum erro foi registrado no processamento deste fascículo.
5. Acesse __OPAC > Issue__
6. Procure um fascículo reprocessado.
7. Verifique se o campo `url_segment` foi registrado com o volume de forma correta.

#### Algum cenário de contexto que queira dar?
Conforme descrito no ticket scieloorg/opac/issues/1342, os fascículos com volume alfanuméricos estão registrados com o `url_segment` incorreto.

### Screenshots
N/A

#### Quais são tickets relevantes?
#479, scieloorg/opac/issues/1342

### Referências
Nenhuma.

