### PR TITLE
Adiciona os idiomas de HTMLs produzidos através do XML de artigo

### DIFF
--- a/opac_proc/core/assets.py
+++ b/opac_proc/core/assets.py
@@ -510,6 +510,20 @@ class AssetXML(Assets):
                                                    self.get_metadata())
             return xml_url
 
+    def html_languages(self):
+        """
+        Extract all the HTML languages in XML content.
+        """
+        try:
+            generator = HTMLGenerator.parse(self._content, valid_only=False)
+        except ValueError as e:
+            logger.error('Error getting htmlgenerator: {}.'.format(e.message))
+        else:
+            return [
+                {'type': 'html', 'lang': lang}
+                for lang, __ in generator
+            ]
+
 
 class AssetHTMLS(Assets):
 

--- a/opac_proc/transformers/tr_articles.py
+++ b/opac_proc/transformers/tr_articles.py
@@ -183,6 +183,7 @@ class ArticleTransformer(BaseTransformer):
             xml_url = asset_xml.register()
             if xml_url:
                 self.transform_model_instance['xml'] = xml_url
+                self.transform_model_instance['htmls'] = asset_xml.html_languages()
 
         # Versão HTML do artigo
         if hasattr(xylose_article, 'data_model_version') and xylose_article.data_model_version != 'xml':


### PR DESCRIPTION
#### O que esse PR faz?
Para que o site identifique quais idiomas o artigo possui, é necessário que o processamento informe no registro de artigo os idiomas disponíveis no XML.

#### Onde a revisão poderia começar?
Em `opac_proc/core/assets.py`.

#### Como este poderia ser testado manualmente?
1. Selecione um artigo XML que o registro na collection do MongoDB `t_article` não tenha o campo `htmls` ou apague este campo de um registro.
2. Acesse a interface do OPAC-PROC, em Transform > Articles
3. Processe a transformação do artigo selecionado
4. Verifique se a transformação foi executada com sucesso
5. O campo `htmls` no registro deste artigo deve estar com os idiomas disponíveis no XML

#### Algum cenário de contexto que queira dar?
Este campo foi retirado com a renderização dos HTMLs no processo de transformação, pois a partir da versão 3 do site os HTMLs são renderizados pela aplicação OPAC em tempo real (no acesso ao artigo). Porém, para que o Issue TOC consiga exibir os textos disponíveis do artigo, o site consulta os idiomas do campo `htmls` dos registros dos artigos.

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac/issues/1382 scieloorg/opac/issues/1290

### Referências
Nenhuma.
