### PR TITLE
Corrige filtro das listagens

### DIFF
--- a/opac_proc/web/static/js/filters_toolbar.js
+++ b/opac_proc/web/static/js/filters_toolbar.js
@@ -79,8 +79,8 @@ window.FilterToolbar = {
       if (fdata['type'] == 'date_time') {
         var from_opts = Object.create(this._datepicker_default_opts);
         var until_opts = Object.create(this._datepicker_default_opts);
-        var from_dt = $('#' + fdata['datetimepicker_from_id']);
-        var until_td = $('#' + fdata['datetimepicker_until_id']);
+        var from_dt = $('#' + fdata['datetimepicker_from_id'].replace(/\./g, "\\."));
+        var until_td = $('#' + fdata['datetimepicker_until_id'].replace(/\./g, "\\."));
 
         if (fdata['param_value_from'] !== "") {
           from_opts['defaultDate'] = fdata['param_value_from'];

--- a/opac_proc/web/views/generics/list_views.py
+++ b/opac_proc/web/views/generics/list_views.py
@@ -116,9 +116,6 @@ class ListView(View):
                 f_field_type = list_filter['field_type']
                 f_field_label = list_filter['field_label']
 
-                if '.' in f_field_name:
-                    f_field_name = f_field_name.replace('.', '__')
-
                 qs_filter_value = request.args.get('filter__value__%s' % f_field_name, None)
                 qs_filter_from = request.args.get('filter__value__from__%s' % f_field_name, None)
                 qs_filter_until = request.args.get('filter__value__until__%s' % f_field_name, None)
@@ -193,7 +190,11 @@ class ListView(View):
         else:
             filters = self.get_filters()
             if self.list_filters and filters:
-                return self.model_class.objects.filter(**filters)
+                _filters = {
+                    field.replace('.', '__'): value
+                    for field, value in filters.items()
+                }
+                return self.model_class.objects.filter(**_filters)
             else:
                 return self.model_class.objects()
 


### PR DESCRIPTION
#### O que esse PR faz?
Os filtros de subcampos de campo `metadata` em todas as listagens não estavam funcionando (datas, processamento completo e reprocessar). Além de alterar o `list_view` para fazer corretamente o filtro pelo mongoengine, foi alterada a barra de filtro em JS para obter corretamente nomes de campos com `.`.

#### Onde a revisão poderia começar?
Em `opac_proc/web/static/js/filters_toolbar.js`

#### Como este poderia ser testado manualmente?
- Acesse as listagens de extração, transformação ou carga
- Utilize os filtros de conteúdos por data da última alteração, processamento completo e reprocessar e todos devem funcionar corretamente.
- Utilize os outros filtros string presentes nas listagens e todos devem permanecer funcionando.

#### Algum cenário de contexto que queira dar?
Este erro foi encontrado em situação de necessidade de reprocessamento de conteúdo e é essencial para fazê-lo de forma mais rápida.

### Screenshots
N/A

#### Quais são tickets relevantes?
-

### Referências
Nenhuma.


