### PR TITLE
Altera a versão do opac_schema para receber mais do que um e-mail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ blinker==1.4
 mongolog==0.1.1
 xylose==1.35.0
 -e git+https://git@github.com/scieloorg/legendarium@2.0.4#egg=legendarium
--e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.54#egg=opac_schema
 scieloh5m5==1.11.0
 requests==2.21.0
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
#### O que esse PR faz?

Altera a versão do opac_schema para receber mais do que um e-mail

#### Onde a revisão poderia começar?

No arquivo de **requirements.txt**

#### Como este poderia ser testado manualmente?

Iniciando o opac-proc e realizando a fase de **extract, transform e load** da entidade Journal.

#### Algum cenário de contexto que queira dar?

Foi realizado teste manual localmente e a fase de carga está funcionando corretamente

### Screenshots

Foi alterado o dado de forma manual no periódico Physis: 

<img width="1674" alt="Screenshot 2019-12-09 16 30 41" src="https://user-images.githubusercontent.com/373745/70466181-549f3c00-1aa1-11ea-80c6-a58bc5984fab.png">


<img width="1680" alt="Screenshot 2019-12-09 16 31 32" src="https://user-images.githubusercontent.com/373745/70466196-5e28a400-1aa1-11ea-99b2-b6274cbb8353.png">


#### Quais são tickets relevantes?

https://github.com/scieloorg/opac_proc/issues/523

### Referências
N/A


