### PR TITLE
Atualiza versão do OPAC_Schema da 2.52 para 2.54

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ blinker==1.4
 mongolog==0.1.1
 xylose==1.35.0
 -e git+https://git@github.com/scieloorg/legendarium@2.0.5#egg=legendarium
--e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
+-e git+https://git@github.com/scieloorg/opac_schema@v2.54#egg=opac_schema
 scieloh5m5==1.11.0
 requests==2.21.0
 Flask-DebugToolbar==0.10.1


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza versão do opac_schema para corrigir o problema do campo de email do editor, que está sendo usado como campo texto.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
- Busque um periódico que tenha o campo de email do editor com mais de 1 endereço de email separado por ponto e vírgula ou barra.

#### Algum cenário de contexto que queira dar?
Estes periódicos não estavam sendo atualizados no OPAC por conta da validação de emails que existia no Opac Schema. O campo foi transformado em texto e a validação não será mais feita.

### Screenshots
n/a

#### Quais são tickets relevantes?
#523 

### Referências
Nenhuma.