### PR TITLE
Altera Load do site p/ obter último registro de artigo transformado

### DIFF
--- a/opac_proc/loaders/base.py
+++ b/opac_proc/loaders/base.py
@@ -102,7 +102,7 @@ class BaseLoader(object):
         # caso não exista, levantamos uma exeção por não ter o dado fonte
         with switch_db(self.transform_model_class, OPAC_PROC_DB_NAME) as transform_model_class:
             logger.debug(u'recuperando modelo: %s' % self.transform_model_name)
-            self.transform_model_instance = transform_model_class.objects(**query_dict).first()
+            self.transform_model_instance = transform_model_class.objects(**query_dict).order_by('-updated_at').first()
             logger.debug(u'modelo %s encontrado. query_dict: %s' % (self.transform_model_name, query_dict))
 
     def get_opac_model_instance(self, query_dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ prometheus-client==0.4.2
 beautifulsoup4==4.6.3
 mock==2.0.0
 redis==2.10.6
+email-validator==1.1.1


### PR DESCRIPTION
#### O que esse PR faz?
Este PR garante que, ao carregar os artigos transformados para o site, obtenha sempre o último registro transformado. Os registros são ordenados pela data de atualização do registro.

#### Onde a revisão poderia começar?
Commit 7f370f1

#### Como este poderia ser testado manualmente?
Com um fascículo de periódico com atualização de seções:
- Insira na scilista o acrônimo do periódico e o fascículo
- Execute o comando `python opac_proc/manage.py process_extract -f data/scilista.lst` e verifique que nenhum erro ocorreu no dashboard da interface WEB em `/dashboard`
- Execute o comando `python opac_proc/manage.py process_transform -f data/scilista.lst` e verifique que nenhum erro ocorreu no dashboard
- Execute o comando `python opac_proc/manage.py process_load -f data/scilista.lst` e verifique que nenhum erro ocorreu no dashboard

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Quando aplicável e se fizer possível adicione screenshots que remetem a situação gráfica do problema que o pull request resolve.

#### Quais são tickets relevantes?
#576 

### Referências
.